### PR TITLE
Switch modified cache from map to LRU. Fixes #2

### DIFF
--- a/iradix.go
+++ b/iradix.go
@@ -1,6 +1,19 @@
 package iradix
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+const (
+	// defaultModifiedCache is the default size of the modified node
+	// cache used in per transaction. This is used to cache the updates
+	// to the nodes near the root, while the leaves do not need to be
+	// cached. This is important for very large transactions to prevent
+	// the modified cache from growing to be enormous.
+	defaultModifiedCache = 8192
+)
 
 // Tree implements an immutable radix tree. This can be treated as a
 // Dictionary abstract data type. The main advantage over a standard
@@ -29,7 +42,7 @@ func (t *Tree) Len() int {
 type Txn struct {
 	root     *Node
 	size     int
-	modified map[*Node]struct{}
+	modified *simplelru.LRU
 }
 
 // Txn starts a new transaction that can be used to mutate the tree
@@ -47,12 +60,16 @@ func (t *Tree) Txn() *Txn {
 func (t *Txn) writeNode(n *Node) *Node {
 	// Ensure the modified set exists
 	if t.modified == nil {
-		t.modified = make(map[*Node]struct{})
+		lru, err := simplelru.NewLRU(defaultModifiedCache, nil)
+		if err != nil {
+			panic(err)
+		}
+		t.modified = lru
 	}
 
 	// If this node has already been modified, we can
 	// continue to use it during this transaction.
-	if _, ok := t.modified[n]; ok {
+	if _, ok := t.modified.Get(n); ok {
 		return n
 	}
 
@@ -72,7 +89,7 @@ func (t *Txn) writeNode(n *Node) *Node {
 	}
 
 	// Mark this node as modified
-	t.modified[nc] = struct{}{}
+	t.modified.Add(n, nil)
 	return nc
 }
 


### PR DESCRIPTION
Switches the internal modified node tracker from a map to an LRU cache. This solves the memory explosion in very large transactions since we really only need to cache the nodes close to the root, the leaves are not important as they are generally only modified once within the transaction.

/cc: @slackpad 