### PR TITLE
Fix caching problem

### DIFF
--- a/iradix.go
+++ b/iradix.go
@@ -89,7 +89,7 @@ func (t *Txn) writeNode(n *Node) *Node {
 	}
 
 	// Mark this node as modified
-	t.modified.Add(n, nil)
+	t.modified.Add(nc, nil)
 	return nc
 }
 


### PR DESCRIPTION
My understanding is we should cache the newly copied node, otherwise the cache will never be used.

Run the test `TestTest_HugeTxn`, with the fix it takes ~7.5 seconds to run, without the fix it takes ~9.4s.

