### PR TITLE
Adds mutation tracking support.

### DIFF
--- a/iradix.go
+++ b/iradix.go
@@ -48,9 +48,9 @@ type Txn struct {
 	size     int
 	modified *simplelru.LRU
 
-	mutatedNode  map[*Node]struct{}
-	mutatedLeaf  map[*leafNode]struct{}
-	notifyMutate bool
+	mutatedNode map[*Node]struct{}
+	mutatedLeaf map[*leafNode]struct{}
+	trackMutate bool
 }
 
 // Txn starts a new transaction that can be used to mutate the tree
@@ -62,15 +62,12 @@ func (t *Tree) Txn() *Txn {
 	return txn
 }
 
-// TrackMutate can be used to toggle if mutation cause a notification
-// to the affected nodes. This must be enabled before any modifications are
-// made within the transaction.
-func (t *Txn) TrackMutate(notify bool) error {
-	if len(t.modified) > 0 && notify {
-		return fmt.Errorf("transaction already in progress")
-	}
-	t.notifyMutate = notify
-	return nil
+// TrackMutate can be used to toggle if mutations are tracked.
+// This is used with Notify to cause a notification to the affected
+// internal nodes and leaves. Mutations made before enabling tracking
+// will not be notified.
+func (t *Txn) TrackMutate(track bool) {
+	t.trackMutate = track
 }
 
 // writeNode returns a node to be modified, if the current
@@ -93,7 +90,7 @@ func (t *Txn) writeNode(n *Node) *Node {
 	}
 
 	// Mark this node as being mutated
-	if t.notifyMutate {
+	if t.trackMutate {
 		if t.mutatedNode == nil {
 			t.mutatedNode = make(map[*Node]struct{})
 		}
@@ -123,7 +120,7 @@ func (t *Txn) writeNode(n *Node) *Node {
 // mutateLeaf is used to mark a leaf as being mutated
 // for the purposes of notification.
 func (t *Txn) mutateLeaf(leaf *leafNode) {
-	if !t.notifyMutate {
+	if !t.trackMutate {
 		return
 	}
 	if t.mutatedLeaf == nil {
@@ -335,13 +332,11 @@ func (t *Txn) Commit() *Tree {
 // Notify is used along with TrackMutate to trigger notifications.
 // It should only be invoked after the transaction has been committed.
 func (t *Txn) Notify() {
-	if t.notifyMutate {
-		for leaf := range t.mutatedLeaf {
-			close(leaf.mutateCh)
-		}
-		for node := range t.mutatedNode {
-			close(node.mutateCh)
-		}
+	for leaf := range t.mutatedLeaf {
+		close(leaf.mutateCh)
+	}
+	for node := range t.mutatedNode {
+		close(node.mutateCh)
 	}
 	t.mutatedNode = nil
 	t.mutatedLeaf = nil

--- a/iradix.go
+++ b/iradix.go
@@ -2,6 +2,7 @@ package iradix
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/hashicorp/golang-lru/simplelru"
 )
@@ -11,7 +12,9 @@ const (
 	// cache used per transaction. This is used to cache the updates
 	// to the nodes near the root, while the leaves do not need to be
 	// cached. This is important for very large transactions to prevent
-	// the modified cache from growing to be enormous.
+	// the modified cache from growing to be enormous. This is also used
+	// to set the max size of the mutation notify maps since those should
+	// also be bounded in a similar way.
 	defaultModifiedCache = 8192
 )
 
@@ -44,69 +47,109 @@ func (t *Tree) Len() int {
 // atomically and returns a new tree when committed. A transaction
 // is not thread safe, and should only be used by a single goroutine.
 type Txn struct {
-	root     *Node
-	size     int
-	modified *simplelru.LRU
+	// root is the modified root for the transaction.
+	root *Node
 
-	mutatedNode map[*Node]struct{}
-	mutatedLeaf map[*leafNode]struct{}
-	trackMutate bool
+	// snap is a snapshot of the root node for use if we have to run the
+	// slow notify algorithm.
+	snap *Node
+
+	// size tracks the size of the tree as it is modified during the
+	// transaction.
+	size int
+
+	// writable is a cache of writable nodes that have been created during
+	// the course of the transaction. This allows us to re-use the same
+	// nodes for further writes and avoid unnecessary copies of nodes that
+	// have never been exposed outside the transaction. This will only hold
+	// up to defaultModifiedCache number of entries.
+	writable *simplelru.LRU
+
+	// trackChannels is used to hold channels that need to be notified to
+	// signal mutation of the tree. This will only hold up to
+	// defaultModifiedCache number of entries, after which we will set the
+	// trackOverflow flag, which will cause us to use a more expensive
+	// algorithm to perform the notifications. Mutation tracking is only
+	// performed if trackMutate is true.
+	trackChannels map[*chan struct{}]struct{}
+	trackOverflow bool
+	trackMutate   bool
 }
 
 // Txn starts a new transaction that can be used to mutate the tree
 func (t *Tree) Txn() *Txn {
 	txn := &Txn{
 		root: t.root,
+		snap: t.root,
 		size: t.size,
 	}
 	return txn
 }
 
-// TrackMutate can be used to toggle if mutations are tracked.
-// This is used with Notify to cause a notification to the affected
-// internal nodes and leaves. Mutations made before enabling tracking
-// will not be notified.
+// TrackMutate can be used to toggle if mutations are tracked. This is used with
+// Notify to cause a notification to the affected internal nodes and leaves.
+// Mutations made before enabling tracking will not be notified.
 func (t *Txn) TrackMutate(track bool) {
 	t.trackMutate = track
 }
 
-// writeNode returns a node to be modified, if the current node as already been
+// trackChannel safely attempts to track the given mutation channel, setting the
+// overflow flag if we can no longer track any more. This limits the amount of
+// state that will accumulate during a transaction and we have a slower algorithm
+// to switch to if we overflow.
+func (t *Txn) trackChannel(ch *chan struct{}) {
+	// In overflow, make sure we don't store any more objects.
+	if t.trackOverflow {
+		return
+	}
+
+	// Create the map on the fly when we need it.
+	if t.trackChannels == nil {
+		t.trackChannels = make(map[*chan struct{}]struct{})
+	}
+
+	// If this would overflow the state we reject it and set the flag (since
+	// we aren't tracking everything that's required any longer).
+	if len(t.trackChannels) >= defaultModifiedCache {
+		t.trackOverflow = true
+		return
+	}
+
+	// Otherwise we are good to track it.
+	t.trackChannels[ch] = struct{}{}
+}
+
+// writeNode returns a node to be modified, if the current node has already been
 // modified during the course of the transaction, it is used in-place. Set
 // forLeafUpdate to true if you are getting a write node to update the leaf,
 // which will set leaf mutation tracking appropriately as well.
 func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
-	// Ensure the modified set exists.
-	if t.modified == nil {
+	// Ensure the writable set exists.
+	if t.writable == nil {
 		lru, err := simplelru.NewLRU(defaultModifiedCache, nil)
 		if err != nil {
 			panic(err)
 		}
-		t.modified = lru
+		t.writable = lru
 	}
 
 	// If this node has already been modified, we can continue to use it
 	// during this transaction. If a node gets kicked out of cache then we
-	// may notify for its leaf changes if we end up copying the node again,
-	// but we don't make any guarantees about notifying for leaves that
-	// change multiple times *within* a transaction.
-	if _, ok := t.modified.Get(n); ok {
+	// *may* notify for its mutation if we end up copying the node again,
+	// but we don't make any guarantees about notifying for intermediate
+	// mutations that were never exposed outside of a transaction.
+	if _, ok := t.writable.Get(n); ok {
 		return n
 	}
 
 	// Mark this node as being mutated.
 	if t.trackMutate {
-		if t.mutatedNode == nil {
-			t.mutatedNode = make(map[*Node]struct{})
-		}
-		t.mutatedNode[n] = struct{}{}
+		t.trackChannel(&(n.mutateCh))
 	}
 
 	// Mark its leaf as being mutated, if appropriate.
 	if t.trackMutate && forLeafUpdate && n.leaf != nil {
-		if t.mutatedLeaf == nil {
-			t.mutatedLeaf = make(map[*leafNode]struct{})
-		}
-		t.mutatedLeaf[n.leaf] = struct{}{}
+		t.trackChannel(&(n.leaf.mutateCh))
 	}
 
 	// Copy the existing node.
@@ -123,8 +166,8 @@ func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
 		copy(nc.edges, n.edges)
 	}
 
-	// Mark this node as modified.
-	t.modified.Add(nc, nil)
+	// Mark this node as writable.
+	t.writable.Add(nc, nil)
 	return nc
 }
 
@@ -230,7 +273,7 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 
 // delete does a recursive deletion
 func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
-	// Check for key exhaution
+	// Check for key exhaustion
 	if len(search) == 0 {
 		if !n.isLeaf() {
 			return nil, nil
@@ -261,7 +304,10 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		return nil, nil
 	}
 
-	// Copy this node
+	// Copy this node. WATCH OUT - it's safe to pass "false" here because we
+	// will only ADD a leaf via nc.mergeChilde() if there isn't one due to
+	// the !nc.isLeaf() check in the logic just below. This is pretty subtle,
+	// so be careful if you change any of the logic here.
 	nc := t.writeNode(n, false)
 
 	// Delete the edge if the node has no edges
@@ -325,21 +371,90 @@ func (t *Txn) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 // Commit is used to finalize the transaction and return a new tree
 func (t *Txn) Commit() *Tree {
 	nt := &Tree{t.root, t.size}
-	t.modified = nil
+	t.writable = nil
 	return nt
+}
+
+// slowNotify does a complete comparison of the before and after trees in order
+// to trigger notifications. This doesn't require any additional state but it
+// is very expensive to compute.
+func (t *Txn) slowNotify() {
+	snapIter := t.snap.rawIterator()
+	rootIter := t.root.rawIterator()
+	for snapIter.Front() != nil || rootIter.Front() != nil {
+		// If we've exhausted the nodes in the old snapshot, we know
+		// there's nothing remaining to notify.
+		if snapIter.Front() == nil {
+			return
+		}
+		snapElem := snapIter.Front()
+
+		// If we've exhausted the nodes in the new root, we know we need
+		// to invalidate everything that remains in the old snapshot. We
+		// know from the loop condition there's something in the old
+		// snapshot.
+		if rootIter.Front() == nil {
+			close(snapElem.mutateCh)
+			if snapElem.isLeaf() {
+				close(snapElem.leaf.mutateCh)
+			}
+			snapIter.Next()
+			continue
+		}
+
+		// Do one string compare so we can check the various conditions
+		// below without repeating the compare.
+		cmp := strings.Compare(snapIter.Path(), rootIter.Path())
+
+		// If the snapshot is behind the root, then we must have deleted
+		// this node during the transaction.
+		if cmp < 0 {
+			close(snapElem.mutateCh)
+			if snapElem.isLeaf() {
+				close(snapElem.leaf.mutateCh)
+			}
+			snapIter.Next()
+			continue
+		}
+
+		// If the snapshot is ahead of the root, then we must have added
+		// this node during the transaction.
+		if cmp > 0 {
+			rootIter.Next()
+			continue
+		}
+
+		// If we have the same path, then we need to see if we mutated a
+		// node and possibly the leaf.
+		rootElem := rootIter.Front()
+		if snapElem != rootElem {
+			close(snapElem.mutateCh)
+			if snapElem.leaf != nil && (snapElem.leaf != rootElem.leaf) {
+				close(snapElem.leaf.mutateCh)
+			}
+		}
+		snapIter.Next()
+		rootIter.Next()
+	}
 }
 
 // Notify is used along with TrackMutate to trigger notifications.
 // It should only be invoked after the transaction has been committed.
 func (t *Txn) Notify() {
-	for leaf := range t.mutatedLeaf {
-		close(leaf.mutateCh)
+	// If we've overflowed the tracking state we can't use it in any way and
+	// need to do a full tree compare.
+	if t.trackOverflow {
+		t.slowNotify()
+	} else {
+		for ch := range t.trackChannels {
+			close(*ch)
+		}
 	}
-	for node := range t.mutatedNode {
-		close(node.mutateCh)
-	}
-	t.mutatedNode = nil
-	t.mutatedLeaf = nil
+
+	// Clean up the tracking state so that a re-notify is safe (will trigger
+	// the else clause above which will be a no-op).
+	t.trackChannels = nil
+	t.trackOverflow = false
 }
 
 // Insert is used to add or update a given key. The return provides

--- a/iradix.go
+++ b/iradix.go
@@ -132,17 +132,20 @@ func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
 func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface{}, bool) {
 	// Handle key exhaustion
 	if len(search) == 0 {
+		var oldVal interface{}
+		var didUpdate bool
+		if n.isLeaf() {
+			oldVal = n.leaf.val
+			didUpdate = true
+		}
+
 		nc := t.writeNode(n, true)
 		nc.leaf = &leafNode{
 			mutateCh: make(chan struct{}),
 			key:      k,
 			val:      v,
 		}
-		if n.isLeaf() {
-			return nc, n.leaf.val, true
-		} else {
-			return nc, nil, false
-		}
+		return nc, oldVal, didUpdate
 	}
 
 	// Look for the edge

--- a/iradix.go
+++ b/iradix.go
@@ -328,6 +328,13 @@ func (t *Txn) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 // Commit is used to finalize the transaction and return a new tree
 func (t *Txn) Commit() *Tree {
 	nt := &Tree{t.root, t.size}
+	t.modified = nil
+	return nt
+}
+
+// Notify is used along with NotifyMutate to trigger notifications.
+// It should only be invoked after the transaction has been committed.
+func (t *Txn) Notify() {
 	if t.notifyMutate {
 		for leaf := range t.mutatedLeaf {
 			close(leaf.mutateCh)
@@ -336,10 +343,8 @@ func (t *Txn) Commit() *Tree {
 			close(node.mutateCh)
 		}
 	}
-	t.modified = nil
 	t.mutatedNode = nil
 	t.mutatedLeaf = nil
-	return nt
 }
 
 // Insert is used to add or update a given key. The return provides

--- a/iradix.go
+++ b/iradix.go
@@ -315,6 +315,12 @@ func (t *Txn) Get(k []byte) (interface{}, bool) {
 	return t.root.Get(k)
 }
 
+// GetWatch is used to lookup a specific key, returning
+// the watch channel, value and if it was found
+func (t *Txn) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
+	return t.root.GetWatch(k)
+}
+
 // Commit is used to finalize the transaction and return a new tree
 func (t *Txn) Commit() *Tree {
 	nt := &Tree{t.root, t.size}

--- a/iradix.go
+++ b/iradix.go
@@ -176,7 +176,7 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 	// Handle key exhaustion
 	if len(search) == 0 {
 		var oldVal interface{}
-		var didUpdate bool
+		didUpdate := false
 		if n.isLeaf() {
 			oldVal = n.leaf.val
 			didUpdate = true

--- a/iradix.go
+++ b/iradix.go
@@ -62,10 +62,10 @@ func (t *Tree) Txn() *Txn {
 	return txn
 }
 
-// NotifyMutate can be used to toggle if mutation cause a notification
+// TrackMutate can be used to toggle if mutation cause a notification
 // to the affected nodes. This must be enabled before any modifications are
 // made within the transaction.
-func (t *Txn) NotifyMutate(notify bool) error {
+func (t *Txn) TrackMutate(notify bool) error {
 	if len(t.modified) > 0 && notify {
 		return fmt.Errorf("transaction already in progress")
 	}
@@ -332,7 +332,7 @@ func (t *Txn) Commit() *Tree {
 	return nt
 }
 
-// Notify is used along with NotifyMutate to trigger notifications.
+// Notify is used along with TrackMutate to trigger notifications.
 // It should only be invoked after the transaction has been committed.
 func (t *Txn) Notify() {
 	if t.notifyMutate {

--- a/iradix.go
+++ b/iradix.go
@@ -27,7 +27,11 @@ type Tree struct {
 
 // New returns an empty Tree
 func New() *Tree {
-	t := &Tree{root: &Node{}}
+	t := &Tree{
+		root: &Node{
+			mutateCh: make(chan struct{}),
+		},
+	}
 	return t
 }
 

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -606,7 +606,7 @@ func TestMergeChildVisibility(t *testing.T) {
 }
 
 func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		r := New()
 
 		keys := []string{
@@ -642,10 +642,14 @@ func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 		txn := r.Txn()
 		txn.TrackMutate(true)
 		txn.Insert([]byte("foobarbaz"), nil)
-		r = txn.Commit()
-		if i == 0 {
-			txn.Notify()
-		} else {
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.commit()
+			txn.notify()
+		default:
+			r = txn.commit()
 			txn.slowNotify()
 		}
 
@@ -692,10 +696,14 @@ func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 		txn = r.Txn()
 		txn.TrackMutate(true)
 		txn.Delete([]byte("foobarbaz"))
-		r = txn.Commit()
-		if i == 0 {
-			txn.Notify()
-		} else {
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.commit()
+			txn.notify()
+		default:
+			r = txn.commit()
 			txn.slowNotify()
 		}
 
@@ -729,7 +737,7 @@ func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 }
 
 func TestTrackMutate_GetWatch(t *testing.T) {
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		r := New()
 
 		keys := []string{
@@ -773,10 +781,14 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 		txn := r.Txn()
 		txn.TrackMutate(true)
 		txn.Insert([]byte("foobarbaz"), nil)
-		r = txn.Commit()
-		if i == 0 {
-			txn.Notify()
-		} else {
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.commit()
+			txn.notify()
+		default:
+			r = txn.commit()
 			txn.slowNotify()
 		}
 
@@ -817,10 +829,14 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 		txn = r.Txn()
 		txn.TrackMutate(true)
 		txn.Insert([]byte("foobar"), nil)
-		r = txn.Commit()
-		if i == 0 {
-			txn.Notify()
-		} else {
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.commit()
+			txn.notify()
+		default:
+			r = txn.commit()
 			txn.slowNotify()
 		}
 
@@ -868,10 +884,14 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 		txn = r.Txn()
 		txn.TrackMutate(true)
 		txn.Delete([]byte("foobarbaz"))
-		r = txn.Commit()
-		if i == 0 {
-			txn.Notify()
-		} else {
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.commit()
+			txn.notify()
+		default:
+			r = txn.commit()
 			txn.slowNotify()
 		}
 
@@ -912,10 +932,14 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 		txn = r.Txn()
 		txn.TrackMutate(true)
 		txn.Delete([]byte("foobar"))
-		r = txn.Commit()
-		if i == 0 {
-			txn.Notify()
-		} else {
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.commit()
+			txn.notify()
+		default:
+			r = txn.commit()
 			txn.slowNotify()
 		}
 
@@ -1026,13 +1050,13 @@ func TestTrackMutate_HugeTxn(t *testing.T) {
 	txn.Insert([]byte("foobarbaz"), nil)
 
 	// Commit and make sure we overflowed but didn't take on extra stuff.
-	r = txn.Commit()
+	r = txn.commit()
 	if !txn.trackOverflow || len(txn.trackChannels) != defaultModifiedCache {
 		t.Fatalf("bad")
 	}
 
 	// Now do the trigger.
-	txn.Notify()
+	txn.notify()
 
 	// Verify the watches fired as expected.
 	select {

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -621,6 +621,7 @@ func TestNotifyMutate_SeekPrefixWatch(t *testing.T) {
 	txn.NotifyMutate(true)
 	txn.Insert([]byte("foobarbaz"), nil)
 	r = txn.Commit()
+	txn.Notify()
 
 	// Verify root and parent triggered, not leaf affected
 	select {
@@ -666,6 +667,7 @@ func TestNotifyMutate_SeekPrefixWatch(t *testing.T) {
 	txn.NotifyMutate(true)
 	txn.Delete([]byte("foobarbaz"))
 	r = txn.Commit()
+	txn.Notify()
 
 	// Verify root and parent triggered, not leaf affected
 	select {
@@ -740,6 +742,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 	txn.NotifyMutate(true)
 	txn.Insert([]byte("foobarbaz"), nil)
 	r = txn.Commit()
+	txn.Notify()
 
 	// Verify root and parent triggered, not leaf affected
 	select {
@@ -779,6 +782,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 	txn.NotifyMutate(true)
 	txn.Insert([]byte("foobar"), nil)
 	r = txn.Commit()
+	txn.Notify()
 
 	select {
 	case <-rootWatch:
@@ -825,6 +829,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 	txn.NotifyMutate(true)
 	txn.Delete([]byte("foobarbaz"))
 	r = txn.Commit()
+	txn.Notify()
 
 	// Verify root and parent triggered, not leaf affected
 	select {
@@ -864,6 +869,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 	txn.NotifyMutate(true)
 	txn.Delete([]byte("foobar"))
 	r = txn.Commit()
+	txn.Notify()
 
 	select {
 	case <-rootWatch:

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -174,6 +174,26 @@ func TestRoot(t *testing.T) {
 	}
 }
 
+func TestInsert_UpdateFeedback(t *testing.T) {
+	r := New()
+	txn1 := r.Txn()
+
+	for i := 0; i < 10; i++ {
+		var old interface{}
+		var didUpdate bool
+		old, didUpdate = txn1.Insert([]byte("helloworld"), i)
+		if i == 0 {
+			if old != nil || didUpdate {
+				t.Fatalf("bad: %d %v %v", i, old, didUpdate)
+			}
+		} else {
+			if old == nil || old.(int) != i-1 || !didUpdate {
+				t.Fatalf("bad: %d %v %v", i, old, didUpdate)
+			}
+		}
+	}
+}
+
 func TestDelete(t *testing.T) {
 	r := New()
 	s := []string{"", "A", "AB"}

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -584,7 +584,7 @@ func TestMergeChildVisibility(t *testing.T) {
 	}
 }
 
-func TestNotifyMutate_SeekPrefixWatch(t *testing.T) {
+func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 	r := New()
 
 	keys := []string{
@@ -618,7 +618,7 @@ func TestNotifyMutate_SeekPrefixWatch(t *testing.T) {
 
 	// Write to a sub-child should trigger the leaf!
 	txn := r.Txn()
-	txn.NotifyMutate(true)
+	txn.TrackMutate(true)
 	txn.Insert([]byte("foobarbaz"), nil)
 	r = txn.Commit()
 	txn.Notify()
@@ -664,7 +664,7 @@ func TestNotifyMutate_SeekPrefixWatch(t *testing.T) {
 
 	// Delete to a sub-child should not trigger the leaf!
 	txn = r.Txn()
-	txn.NotifyMutate(true)
+	txn.TrackMutate(true)
 	txn.Delete([]byte("foobarbaz"))
 	r = txn.Commit()
 	txn.Notify()
@@ -697,7 +697,7 @@ func TestNotifyMutate_SeekPrefixWatch(t *testing.T) {
 	}
 }
 
-func TestNotifyMutate_GetWatch(t *testing.T) {
+func TestTrackMutate_GetWatch(t *testing.T) {
 	r := New()
 
 	keys := []string{
@@ -739,7 +739,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 
 	// Write to a sub-child should not trigger the leaf!
 	txn := r.Txn()
-	txn.NotifyMutate(true)
+	txn.TrackMutate(true)
 	txn.Insert([]byte("foobarbaz"), nil)
 	r = txn.Commit()
 	txn.Notify()
@@ -779,7 +779,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 
 	// Write to a exactly leaf should trigger the leaf!
 	txn = r.Txn()
-	txn.NotifyMutate(true)
+	txn.TrackMutate(true)
 	txn.Insert([]byte("foobar"), nil)
 	r = txn.Commit()
 	txn.Notify()
@@ -826,7 +826,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 
 	// Delete to a sub-child should not trigger the leaf!
 	txn = r.Txn()
-	txn.NotifyMutate(true)
+	txn.TrackMutate(true)
 	txn.Delete([]byte("foobarbaz"))
 	r = txn.Commit()
 	txn.Notify()
@@ -866,7 +866,7 @@ func TestNotifyMutate_GetWatch(t *testing.T) {
 
 	// Write to a exactly leaf should trigger the leaf!
 	txn = r.Txn()
-	txn.NotifyMutate(true)
+	txn.TrackMutate(true)
 	txn.Delete([]byte("foobar"))
 	r = txn.Commit()
 	txn.Notify()

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -912,3 +912,27 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 	default:
 	}
 }
+
+func TestTrackMutate_HugeTxn(t *testing.T) {
+	r := New()
+
+	keys := []string{
+		"foo/",
+		"foo/b",
+		"foo/bar",
+		"foot",
+		"football",
+	}
+	for _, k := range keys {
+		r, _, _ = r.Insert([]byte(k), nil)
+	}
+	if r.Len() != len(keys) {
+		t.Fatalf("bad len: %v %v", r.Len(), len(keys))
+	}
+
+	txn := r.Txn()
+	txn.TrackMutate(true)
+	txn.Insert([]byte("foobarbaz"), nil)
+	r = txn.Commit()
+	txn.slowNotify()
+}

--- a/node.go
+++ b/node.go
@@ -12,8 +12,9 @@ type WalkFn func(k []byte, v interface{}) bool
 
 // leafNode is used to represent a value
 type leafNode struct {
-	key []byte
-	val interface{}
+	mutateCh chan struct{}
+	key      []byte
+	val      interface{}
 }
 
 // edge is used to represent an edge node
@@ -24,6 +25,9 @@ type edge struct {
 
 // Node is an immutable node in the radix tree
 type Node struct {
+	// mutateCh is closed if this node is modified
+	mutateCh chan struct{}
+
 	// leaf is used to store possible leaf
 	leaf *leafNode
 
@@ -105,13 +109,14 @@ func (n *Node) mergeChild() {
 	}
 }
 
-func (n *Node) Get(k []byte) (interface{}, bool) {
+func (n *Node) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 	search := k
+	watch := n.mutateCh
 	for {
 		// Check for key exhaution
 		if len(search) == 0 {
 			if n.isLeaf() {
-				return n.leaf.val, true
+				return n.leaf.mutateCh, n.leaf.val, true
 			}
 			break
 		}
@@ -122,6 +127,9 @@ func (n *Node) Get(k []byte) (interface{}, bool) {
 			break
 		}
 
+		// Update to the finest granularity as the search makes progress
+		watch = n.mutateCh
+
 		// Consume the search prefix
 		if bytes.HasPrefix(search, n.prefix) {
 			search = search[len(n.prefix):]
@@ -129,7 +137,12 @@ func (n *Node) Get(k []byte) (interface{}, bool) {
 			break
 		}
 	}
-	return nil, false
+	return watch, nil, false
+}
+
+func (n *Node) Get(k []byte) (interface{}, bool) {
+	_, val, ok := n.GetWatch(k)
+	return val, ok
 }
 
 // LongestPrefix is like Get, but instead of an

--- a/node.go
+++ b/node.go
@@ -217,6 +217,14 @@ func (n *Node) Iterator() *Iterator {
 	return &Iterator{node: n}
 }
 
+// rawIterator is used to return a raw iterator at the given node to walk the
+// tree.
+func (n *Node) rawIterator() *rawIterator {
+	iter := &rawIterator{node: n}
+	iter.Next()
+	return iter
+}
+
 // Walk is used to walk the tree
 func (n *Node) Walk(fn WalkFn) {
 	recursiveWalk(n, fn)

--- a/node.go
+++ b/node.go
@@ -113,7 +113,7 @@ func (n *Node) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 	search := k
 	watch := n.mutateCh
 	for {
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			if n.isLeaf() {
 				return n.leaf.mutateCh, n.leaf.val, true

--- a/raw_iter.go
+++ b/raw_iter.go
@@ -1,0 +1,78 @@
+package iradix
+
+// rawIterator visits each of the nodes in the tree, even the ones that are not
+// leaves. It keeps track of the effective path (what a leaf at a given node
+// would be called), which is useful for comparing trees.
+type rawIterator struct {
+	// node is the starting node in the tree for the iterator.
+	node *Node
+
+	// stack keeps track of edges in the frontier.
+	stack []rawStackEntry
+
+	// pos is the current position of the iterator.
+	pos *Node
+
+	// path is the effective path of the current iterator position,
+	// regardless of whether the current node is a leaf.
+	path string
+}
+
+// rawStackEntry is used to keep track of the cumulative common path as well as
+// its associated edges in the frontier.
+type rawStackEntry struct {
+	path  string
+	edges edges
+}
+
+// Front returns the current node that has been iterated to.
+func (i *rawIterator) Front() *Node {
+	return i.pos
+}
+
+// Path returns the effective path of the current node, even if it's not actually
+// a leaf.
+func (i *rawIterator) Path() string {
+	return i.path
+}
+
+// Next advances the iterator to the next node.
+func (i *rawIterator) Next() {
+	// Initialize our stack if needed.
+	if i.stack == nil && i.node != nil {
+		i.stack = []rawStackEntry{
+			rawStackEntry{
+				edges: edges{
+					edge{node: i.node},
+				},
+			},
+		}
+	}
+
+	for len(i.stack) > 0 {
+		// Inspect the last element of the stack.
+		n := len(i.stack)
+		last := i.stack[n-1]
+		elem := last.edges[0].node
+
+		// Update the stack.
+		if len(last.edges) > 1 {
+			i.stack[n-1].edges = last.edges[1:]
+		} else {
+			i.stack = i.stack[:n-1]
+		}
+
+		// Push the edges onto the frontier.
+		if len(elem.edges) > 0 {
+			path := last.path + string(elem.prefix)
+			i.stack = append(i.stack, rawStackEntry{path, elem.edges})
+		}
+
+		i.pos = elem
+		i.path = last.path + string(elem.prefix)
+		return
+	}
+
+	i.pos = nil
+	i.path = ""
+}


### PR DESCRIPTION
This completes the work started by @armon under https://github.com/hashicorp/go-immutable-radix/tree/f-watch and adds a fallback algorithm that doesn't require full mutation tracking for huge transactions.