### PR TITLE
Free notification channels upon overflow

### DIFF
--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1051,7 +1051,7 @@ func TestTrackMutate_HugeTxn(t *testing.T) {
 
 	// Commit and make sure we overflowed but didn't take on extra stuff.
 	r = txn.commit()
-	if !txn.trackOverflow || len(txn.trackChannels) != defaultModifiedCache {
+	if !txn.trackOverflow || txn.trackChannels != nil {
 		t.Fatalf("bad")
 	}
 


### PR DESCRIPTION
This PR clears the notification channels as soon as we enter the
overflow state. This is an optimization to allow earlier garbage
collection of a large amount of channels.