### PR TITLE
Fixes several mutation tracking issues with leaf nodes.

### DIFF
--- a/iradix_test.go
+++ b/iradix_test.go
@@ -605,6 +605,31 @@ func TestMergeChildVisibility(t *testing.T) {
 	}
 }
 
+// isClosed returns true if the given channel is closed.
+func isClosed(ch chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+// hasAnyClosedMutateCh scans the given tree and returns true if there are any
+// closed mutate channels on any nodes or leaves.
+func hasAnyClosedMutateCh(r *Tree) bool {
+	for iter := r.root.rawIterator(); iter.Front() != nil; iter.Next() {
+		n := iter.Front()
+		if isClosed(n.mutateCh) {
+			return true
+		}
+		if n.isLeaf() && isClosed(n.leaf.mutateCh) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		r := New()
@@ -651,6 +676,9 @@ func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 		default:
 			r = txn.CommitOnly()
 			txn.slowNotify()
+		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
 		}
 
 		// Verify root and parent triggered, and leaf affected
@@ -705,6 +733,9 @@ func TestTrackMutate_SeekPrefixWatch(t *testing.T) {
 		default:
 			r = txn.CommitOnly()
 			txn.slowNotify()
+		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
 		}
 
 		// Verify root and parent triggered, and leaf affected
@@ -791,6 +822,9 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 			r = txn.CommitOnly()
 			txn.slowNotify()
 		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
+		}
 
 		// Verify root and parent triggered, not leaf affected
 		select {
@@ -838,6 +872,9 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 		default:
 			r = txn.CommitOnly()
 			txn.slowNotify()
+		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
 		}
 
 		select {
@@ -894,6 +931,9 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 			r = txn.CommitOnly()
 			txn.slowNotify()
 		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
+		}
 
 		// Verify root and parent triggered, not leaf affected
 		select {
@@ -941,6 +981,9 @@ func TestTrackMutate_GetWatch(t *testing.T) {
 		default:
 			r = txn.CommitOnly()
 			txn.slowNotify()
+		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
 		}
 
 		select {
@@ -1058,6 +1101,11 @@ func TestTrackMutate_HugeTxn(t *testing.T) {
 	// Now do the trigger.
 	txn.Notify()
 
+	// Make sure no closed channels escaped the transaction.
+	if hasAnyClosedMutateCh(r) {
+		t.Fatalf("bad")
+	}
+
 	// Verify the watches fired as expected.
 	select {
 	case <-rootWatch:
@@ -1088,5 +1136,75 @@ func TestTrackMutate_HugeTxn(t *testing.T) {
 	case <-afterWatch:
 	default:
 		t.Fatalf("bad")
+	}
+}
+
+func TestTrackMutate_mergeChild(t *testing.T) {
+	// This case does a delete of the "acb" leaf, which causes the "aca"
+	// leaf to get merged with the old "ac" node:
+	//
+	//    [root]                [root]
+	//      |a                    |a
+	//    [node]                [node]
+	//   b/    \c              b/    \c
+	//  (ab)  [node]          (ab)  (aca)
+	//       a/    \b
+	//     (aca)  (acb)
+	//
+	for i := 0; i < 3; i++ {
+		r := New()
+		r, _, _ = r.Insert([]byte("ab"), nil)
+		r, _, _ = r.Insert([]byte("aca"), nil)
+		r, _, _ = r.Insert([]byte("acb"), nil)
+		snapIter := r.root.rawIterator()
+
+		// Run through all notification methods as there were bugs in
+		// both that affected these operations. The slowNotify path
+		// would detect copied but otherwise identical leaves as changed
+		// and wrongly close channels. The normal path would fail to
+		// notify on a child node that had been merged.
+		txn := r.Txn()
+		txn.TrackMutate(true)
+		txn.Delete([]byte("acb"))
+		switch i {
+		case 0:
+			r = txn.Commit()
+		case 1:
+			r = txn.CommitOnly()
+			txn.Notify()
+		default:
+			r = txn.CommitOnly()
+			txn.slowNotify()
+		}
+		if hasAnyClosedMutateCh(r) {
+			t.Fatalf("bad")
+		}
+
+		// Run through the old tree and make sure the exact channels we
+		// expected were closed.
+		for ; snapIter.Front() != nil; snapIter.Next() {
+			n := snapIter.Front()
+			path := snapIter.Path()
+			switch path {
+			case "", "a", "ac":
+				if !isClosed(n.mutateCh) || n.leaf != nil {
+					t.Fatalf("bad")
+				}
+			case "ab":
+				if isClosed(n.mutateCh) || isClosed(n.leaf.mutateCh) {
+					t.Fatalf("bad")
+				}
+			case "aca":
+				if !isClosed(n.mutateCh) || isClosed(n.leaf.mutateCh) {
+					t.Fatalf("bad")
+				}
+			case "acb":
+				if !isClosed(n.mutateCh) || !isClosed(n.leaf.mutateCh) {
+					t.Fatalf("bad")
+				}
+			default:
+				t.Fatalf("bad: %s", path)
+			}
+		}
 	}
 }

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1186,19 +1186,19 @@ func TestTrackMutate_mergeChild(t *testing.T) {
 			n := snapIter.Front()
 			path := snapIter.Path()
 			switch path {
-			case "", "a", "ac":
+			case "", "a", "ac": // parent nodes all change
 				if !isClosed(n.mutateCh) || n.leaf != nil {
 					t.Fatalf("bad")
 				}
-			case "ab":
+			case "ab": // unrelated node / sees no change
 				if isClosed(n.mutateCh) || isClosed(n.leaf.mutateCh) {
 					t.Fatalf("bad")
 				}
-			case "aca":
+			case "aca": // this node gets merged, but the leaf doesn't change
 				if !isClosed(n.mutateCh) || isClosed(n.leaf.mutateCh) {
 					t.Fatalf("bad")
 				}
-			case "acb":
+			case "acb": // this node / leaf gets deleted
 				if !isClosed(n.mutateCh) || !isClosed(n.leaf.mutateCh) {
 					t.Fatalf("bad")
 				}
@@ -1217,7 +1217,7 @@ func TestTrackMutate_cachedNodeChange(t *testing.T) {
 	//      |a                    |a
 	//    [node]                [node]
 	//   b/    \c              b/    \c
-	//  (ab)  [node]          (ab)  (aca)
+	//  (ab)  [node]          (ab)  (aca) <- then this leaf gets modified
 	//       a/    \b
 	//     (aca)  (acb)
 	//
@@ -1254,19 +1254,19 @@ func TestTrackMutate_cachedNodeChange(t *testing.T) {
 			n := snapIter.Front()
 			path := snapIter.Path()
 			switch path {
-			case "", "a", "ac":
+			case "", "a", "ac": // parent nodes all change
 				if !isClosed(n.mutateCh) || n.leaf != nil {
 					t.Fatalf("bad")
 				}
-			case "ab":
+			case "ab": // unrelated node / sees no change
 				if isClosed(n.mutateCh) || isClosed(n.leaf.mutateCh) {
 					t.Fatalf("bad")
 				}
-			case "aca":
+			case "aca": // merge changes the node, then we update the leaf
 				if !isClosed(n.mutateCh) || !isClosed(n.leaf.mutateCh) {
 					t.Fatalf("bad")
 				}
-			case "acb":
+			case "acb": // this node / leaf gets deleted
 				if !isClosed(n.mutateCh) || !isClosed(n.leaf.mutateCh) {
 					t.Fatalf("bad")
 				}

--- a/node.go
+++ b/node.go
@@ -91,24 +91,6 @@ func (n *Node) delEdge(label byte) {
 	}
 }
 
-func (n *Node) mergeChild() {
-	e := n.edges[0]
-	child := e.node
-	n.prefix = concat(n.prefix, child.prefix)
-	if child.leaf != nil {
-		n.leaf = new(leafNode)
-		*n.leaf = *child.leaf
-	} else {
-		n.leaf = nil
-	}
-	if len(child.edges) != 0 {
-		n.edges = make([]edge, len(child.edges))
-		copy(n.edges, child.edges)
-	} else {
-		n.edges = nil
-	}
-}
-
 func (n *Node) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 	search := k
 	watch := n.mutateCh


### PR DESCRIPTION
The `mergeChild` issue was the root cause of https://github.com/hashicorp/consul/issues/2724.