### PR TITLE
Fix Len() when deleting keys in a transaction

### DIFF
--- a/iradix.go
+++ b/iradix.go
@@ -338,6 +338,11 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		if !n.isLeaf() {
 			return nil, nil
 		}
+		// Copy the pointer in case we are in a transaction that already
+		// modified this node since the node will be reused. Any changes
+		// made to the node will not affect returning the original leaf
+		// value.
+		oldLeaf := n.leaf
 
 		// Remove the leaf node
 		nc := t.writeNode(n, true)
@@ -347,7 +352,7 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		if n != t.root && len(nc.edges) == 1 {
 			t.mergeChild(nc)
 		}
-		return nc, n.leaf
+		return nc, oldLeaf
 	}
 
 	// Look for an edge

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1488,3 +1488,38 @@ func TestTrackMutate_cachedNodeChange(t *testing.T) {
 		}
 	}
 }
+
+func TestLenTxn(t *testing.T) {
+	r := New()
+
+	if r.Len() != 0 {
+		t.Fatalf("not starting with empty tree")
+	}
+
+	txn := r.Txn()
+	keys := []string{
+		"foo/bar/baz",
+		"foo/baz/bar",
+		"foo/zip/zap",
+		"foobar",
+		"nochange",
+	}
+	for _, k := range keys {
+		txn.Insert([]byte(k), nil)
+	}
+	r = txn.Commit()
+
+	if r.Len() != len(keys) {
+		t.Fatalf("bad: expected %d, got %d", len(keys), r.Len())
+	}
+
+	txn = r.Txn()
+	for _, k := range keys {
+		txn.Delete([]byte(k))
+	}
+	r = txn.Commit()
+
+	if r.Len() != 0 {
+		t.Fatalf("tree len should be zero, got %d", r.Len())
+	}
+}

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -167,7 +167,7 @@ func TestRoot(t *testing.T) {
 	}
 	val, ok := r.Get(nil)
 	if !ok || val != true {
-		t.Fatalf("bad: %v %#v", val)
+		t.Fatalf("bad: %#v", val)
 	}
 	r, val, ok = r.Delete(nil)
 	if !ok || val != true {


### PR DESCRIPTION
When deleting keys in a transaction, the internal size tracker is not being properly decremented when deleting the last node on an edge.

Additionally, I did check the newer DeletePrefix and it is not affected by this issue.