### PR TITLE
Add LowerBound to allow range scans

### DIFF
--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1724,8 +1724,8 @@ func TestIterateLowerBoundFuzz(t *testing.T) {
 	r := New()
 	set := []string{}
 
-	// This species a property where each call adds a new random key to the radix
-	// tree (with a null byte appended since out tree doesn't support one key
+	// This specifies a property where each call adds a new random key to the radix
+	// tree (with a null byte appended since our tree doesn't support one key
 	// being a prefix of another and treats null bytes specially).
 	//
 	// It also maintains a plain sorted list of the same set of keys and asserts

--- a/iter.go
+++ b/iter.go
@@ -88,7 +88,7 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 	}
 
 	for {
-		// Compare current prefix with the seaarch key's same-length prefix.
+		// Compare current prefix with the search key's same-length prefix.
 		var prefixCmp int
 		if len(n.prefix) < len(search) {
 			prefixCmp = bytes.Compare(n.prefix, search[0:len(n.prefix)])

--- a/iter.go
+++ b/iter.go
@@ -1,6 +1,8 @@
 package iradix
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // Iterator is used to iterate over a set of nodes
 // in pre-order
@@ -51,6 +53,69 @@ func (i *Iterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
 // SeekPrefix is used to seek the iterator to a given prefix
 func (i *Iterator) SeekPrefix(prefix []byte) {
 	i.SeekPrefixWatch(prefix)
+}
+
+// SeekLowerBound is used to seek the iterator to the smallest key that is
+// greater or equal to the given key. There is no watch variant as it's hard to
+// predict based on the radix structure which node(s) changes might affect the
+// result.
+func (i *Iterator) SeekLowerBound(key []byte) {
+	// Wipe the stack. Unlike Prefix iteration, we need to build the stack as we
+	// go because we need only a subset of edges of many nodes in the path to the
+	// leaf with the lower bound.
+	i.stack = []edges{}
+	n := i.node
+	search := key
+
+	found := func(n *Node) {
+		i.node = n
+		i.stack = append(i.stack, edges{edge{node: n}})
+	}
+
+	for {
+		// Consume the search prefix
+		if len(n.prefix) > len(search) {
+			search = []byte{}
+		} else {
+			search = search[len(n.prefix):]
+		}
+
+		// Is this a leaf? If so check if it's lower than the key (no lower bound
+		// exists).
+		if n.leaf != nil {
+			if bytes.Compare(n.leaf.key, key) < 0 {
+				i.node = nil
+				return
+			}
+
+			// We are a leaf that is greater or equal, that means we are the lower
+			// bound.
+			found(n)
+			return
+		}
+
+		// Check for key exhaustion
+		if len(search) == 0 {
+			found(n)
+			return
+		}
+
+		// Not a leaf, look for the lower bound edge
+		idx, lbNode := n.getLowerBoundEdge(search[0])
+		if lbNode == nil {
+			i.node = nil
+			return
+		}
+
+		// Create stack edges for the all strictly higher edges in this node.
+		if idx+1 < len(n.edges) {
+			i.stack = append(i.stack, n.edges[idx+1:])
+		}
+
+		i.node = lbNode
+		// Recurse
+		n = lbNode
+	}
 }
 
 // Next returns the next node in order

--- a/node.go
+++ b/node.go
@@ -79,6 +79,18 @@ func (n *Node) getEdge(label byte) (int, *Node) {
 	return -1, nil
 }
 
+func (n *Node) getLowerBoundEdge(label byte) (int, *Node) {
+	num := len(n.edges)
+	idx := sort.Search(num, func(i int) bool {
+		return n.edges[i].label >= label
+	})
+	// we want lower bound behavior so return even if it's not an exact match
+	if idx < num {
+		return idx, n.edges[idx].node
+	}
+	return -1, nil
+}
+
 func (n *Node) delEdge(label byte) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {


### PR DESCRIPTION
This PR adds a `SeekLowerBound` method to `Iterator` which allows for range scans of the radix tree. Lower bound seeks the iterator to the first key that is greater than or equal to some search key. The iterator can then be used to iterate in order over the rest of the values. A caller can simply stop when the result is "to high" to bound the range at the upper end.

For example, assume radix trees are sorted fixed length representation of an integer such as "00001" (these might represent timestamps or some other sparse, monotonically increasing value).

```go
// Keys 00001 00002 00005 00006
it := tree.Root().Iterator()
it.SeekLowerBound([]byte("00003")
for key, _, ok := it.Next(); ok; key, _, ok = it.Next() {
  fmt.Printf("%s", key)
}
// Output:
//   00005
//   00006
```

## Limitations

There is no `*Watch` variant of this seek method because in general there is no single node that is guaranteed to be updated when the lower bound changes (other than the root). Note that even if such an algorithm could be found, it likely isn't what callers want when using this for range scans because it only tells them that the _start_ of the range changed not about any changes in the middle or end of the range.

Callers that need to be notified of changes must arrange for that separately, for example by watching another key that is always updated when events they care about occur, or watching the root node and comparing changes to the lower bound.

## Testing

This was surprisingly subtle to get right with prefix compression. An initial implementation passed a range of example-based table tests but I wasn't confident still so wrote a Fuzz test using `testing/quick` which caught several fundamental flaws.

This implementation now passes table tests, including some based on simplified cases caught by fuzz testing, as well as property-based fuzz testing with random keys and comparison to a simple/naive implementation with a sorted list.
