### PR TITLE
Add reverse traversal

### DIFF
--- a/node.go
+++ b/node.go
@@ -230,6 +230,11 @@ func (n *Node) Walk(fn WalkFn) {
 	recursiveWalk(n, fn)
 }
 
+// WalkBackwards is used to walk the tree in reverse order
+func (n *Node) WalkBackwards(fn WalkFn) {
+	reverseRecursiveWalk(n, fn)
+}
+
 // WalkPrefix is used to walk the tree under a prefix
 func (n *Node) WalkPrefix(prefix []byte, fn WalkFn) {
 	search := prefix
@@ -303,6 +308,25 @@ func recursiveWalk(n *Node, fn WalkFn) bool {
 	// Recurse on the children
 	for _, e := range n.edges {
 		if recursiveWalk(e.node, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// reverseRecursiveWalk is used to do a reverse pre-order
+// walk of a node recursively. Returns true if the walk
+// should be aborted
+func reverseRecursiveWalk(n *Node, fn WalkFn) bool {
+	// Visit the leaf values if any
+	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
+		return true
+	}
+
+	// Recurse on the children in reverse order
+	for i := len(n.edges) - 1; i >= 0; i-- {
+		e := n.edges[i]
+		if reverseRecursiveWalk(e.node, fn) {
 			return true
 		}
 	}

--- a/node.go
+++ b/node.go
@@ -211,6 +211,12 @@ func (n *Node) Iterator() *Iterator {
 	return &Iterator{node: n}
 }
 
+// ReverseIterator is used to return an iterator at
+// the given node to walk the tree backwards
+func (n *Node) ReverseIterator() *ReverseIterator {
+	return NewReverseIterator(n)
+}
+
 // rawIterator is used to return a raw iterator at the given node to walk the
 // tree.
 func (n *Node) rawIterator() *rawIterator {

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,55 @@
+package iradix
+
+import (
+	"testing"
+)
+
+func TestNodeWalk(t *testing.T) {
+	r := New()
+	keys := []string{"001", "002", "005", "010", "100"}
+	for _, k := range keys {
+		r, _, _ = r.Insert([]byte(k), nil)
+	}
+
+	i := 0
+
+	r.Root().Walk(func(k []byte, _ interface{}) bool {
+		got := string(k)
+		want := keys[i]
+		if got != want {
+			t.Errorf("got %s, want: %s", got, want)
+		}
+
+		i++
+		if i >= len(keys) {
+			return true
+		}
+
+		return false
+	})
+}
+
+func TestNodeWalkBackwards(t *testing.T) {
+	r := New()
+	keys := []string{"001", "002", "005", "010", "100"}
+	for _, k := range keys {
+		r, _, _ = r.Insert([]byte(k), nil)
+	}
+
+	i := len(keys) - 1
+
+	r.Root().WalkBackwards(func(k []byte, _ interface{}) bool {
+		got := string(k)
+		want := keys[i]
+		if got != want {
+			t.Errorf("got %s, want: %s", got, want)
+		}
+
+		i--
+		if i < 0 {
+			return true
+		}
+
+		return false
+	})
+}

--- a/reverse_iter.go
+++ b/reverse_iter.go
@@ -34,11 +34,11 @@ func (ri *ReverseIterator) recurseMax(n *Node) *Node {
 		return n
 	}
 	if len(n.edges) > 0 {
-		// Add all the other edges to the stack (the min node will be added as
+		// Add all the other edges to the stack (the max node will be added as
 		// we recurse)
 		m := len(n.edges)
 		ri.i.stack = append(ri.i.stack, n.edges[:m-1])
-		return ri.i.recurseMin(n.edges[m-1].node)
+		return ri.recurseMax(n.edges[m-1].node)
 	}
 	// Shouldn't be possible
 	return nil

--- a/reverse_iter.go
+++ b/reverse_iter.go
@@ -1,0 +1,177 @@
+package iradix
+
+import (
+	"bytes"
+)
+
+// ReverseIterator is used to iterate over a set of nodes
+// in reverse in-order
+type ReverseIterator struct {
+	i *Iterator
+}
+
+// NewReverseIterator returns a new ReverseIterator at a node
+func NewReverseIterator(n *Node) *ReverseIterator {
+	return &ReverseIterator{
+		i: &Iterator{node: n},
+	}
+}
+
+// SeekPrefixWatch is used to seek the iterator to a given prefix
+// and returns the watch channel of the finest granularity
+func (ri *ReverseIterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
+	return ri.i.SeekPrefixWatch(prefix)
+}
+
+// SeekPrefix is used to seek the iterator to a given prefix
+func (ri *ReverseIterator) SeekPrefix(prefix []byte) {
+	ri.i.SeekPrefixWatch(prefix)
+}
+
+func (ri *ReverseIterator) recurseMax(n *Node) *Node {
+	// Traverse to the maximum child
+	if n.leaf != nil {
+		return n
+	}
+	if len(n.edges) > 0 {
+		// Add all the other edges to the stack (the min node will be added as
+		// we recurse)
+		m := len(n.edges)
+		ri.i.stack = append(ri.i.stack, n.edges[:m-1])
+		return ri.i.recurseMin(n.edges[m-1].node)
+	}
+	// Shouldn't be possible
+	return nil
+}
+
+// SeekReverseLowerBound is used to seek the iterator to the largest key that is
+// lower or equal to the given key. There is no watch variant as it's hard to
+// predict based on the radix structure which node(s) changes might affect the
+// result.
+func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
+	// Wipe the stack. Unlike Prefix iteration, we need to build the stack as we
+	// go because we need only a subset of edges of many nodes in the path to the
+	// leaf with the lower bound.
+	ri.i.stack = []edges{}
+	n := ri.i.node
+	search := key
+
+	found := func(n *Node) {
+		ri.i.node = n
+		ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
+	}
+
+	for {
+		// Compare current prefix with the search key's same-length prefix.
+		var prefixCmp int
+		if len(n.prefix) < len(search) {
+			prefixCmp = bytes.Compare(n.prefix, search[0:len(n.prefix)])
+		} else {
+			prefixCmp = bytes.Compare(n.prefix, search)
+		}
+
+		if prefixCmp < 0 {
+			// Prefix is smaller than search prefix, that means there is no lower bound.
+			// But we are looking in reverse, so the reverse lower bound will be the
+			// largest leaf under this subtree, since it is the value that would come
+			// right before the current search prefix if it were in the tree. So we need
+			// to follow the maximum path in this subtree to find it.
+			n = ri.recurseMax(n)
+			if n != nil {
+				found(n)
+			}
+			return
+		}
+
+		if prefixCmp > 0 {
+			// Prefix is larger than search prefix, that means there is no reverse lower
+			// bound since nothing comes before our current search prefix.
+			ri.i.node = nil
+			return
+		}
+
+		// Prefix is equal, we are still heading for an exact match. If this is a
+		// leaf we're done.
+		if n.leaf != nil {
+			if bytes.Compare(n.leaf.key, key) < 0 {
+				ri.i.node = nil
+				return
+			}
+			found(n)
+			return
+		}
+
+		// Consume the search prefix
+		if len(n.prefix) > len(search) {
+			search = []byte{}
+		} else {
+			search = search[len(n.prefix):]
+		}
+
+		// Otherwise, take the lower bound next edge.
+		idx, lbNode := n.getLowerBoundEdge(search[0])
+
+		// From here, we need to update the stack with all values lower than
+		// the lower bound edge. Since getLowerBoundEdge() returns -1 when the
+		// search prefix is larger than all edges, we need to place idx at the
+		// last edge index so they can all be place in the stack, since they
+		// come before our search prefix.
+		if idx == -1 {
+			idx = len(n.edges)
+		}
+
+		// Create stack edges for the all strictly lower edges in this node.
+		if len(n.edges[:idx]) > 0 {
+			ri.i.stack = append(ri.i.stack, n.edges[:idx])
+		}
+
+		// Exit if there's not lower bound edge. The stack will have the
+		// previous nodes already.
+		if lbNode == nil {
+			ri.i.node = nil
+			return
+		}
+
+		ri.i.node = lbNode
+		// Recurse
+		n = lbNode
+	}
+}
+
+// Previous returns the previous node in reverse order
+func (ri *ReverseIterator) Previous() ([]byte, interface{}, bool) {
+	// Initialize our stack if needed
+	if ri.i.stack == nil && ri.i.node != nil {
+		ri.i.stack = []edges{
+			{
+				edge{node: ri.i.node},
+			},
+		}
+	}
+
+	for len(ri.i.stack) > 0 {
+		// Inspect the last element of the stack
+		n := len(ri.i.stack)
+		last := ri.i.stack[n-1]
+		m := len(last)
+		elem := last[m-1].node
+
+		// Update the stack
+		if m > 1 {
+			ri.i.stack[n-1] = last[:m-1]
+		} else {
+			ri.i.stack = ri.i.stack[:n-1]
+		}
+
+		// Push the edges onto the frontier
+		if len(elem.edges) > 0 {
+			ri.i.stack = append(ri.i.stack, elem.edges)
+		}
+
+		// Return the leaf values if any
+		if elem.leaf != nil {
+			return elem.leaf.key, elem.leaf.val, true
+		}
+	}
+	return nil, nil, false
+}

--- a/reverse_iter_test.go
+++ b/reverse_iter_test.go
@@ -128,6 +128,31 @@ func TestReverseIterator_SeekPrefix(t *testing.T) {
 	}
 }
 
+func TestReverseIterator_SeekPrefixWatch(t *testing.T) {
+	key := []byte("key")
+
+	// Create tree
+	r := New()
+	r, _, _ = r.Insert(key, nil)
+
+	// Find mutate channel
+	it := r.Root().ReverseIterator()
+	ch := it.SeekPrefixWatch(key)
+
+	// Change prefix
+	tx := r.Txn()
+	tx.TrackMutate(true)
+	tx.Insert(key, "value")
+	tx.Commit()
+
+	// Check if channel closed
+	select {
+	case <-ch:
+	default:
+		t.Errorf("channel not closed")
+	}
+}
+
 func TestReverseIterator_Previous(t *testing.T) {
 	r := New()
 	keys := []string{"001", "002", "005", "010", "100"}

--- a/reverse_iter_test.go
+++ b/reverse_iter_test.go
@@ -15,8 +15,8 @@ func TestReverseIterator_SeekReverseLowerBoundFuzz(t *testing.T) {
 	// being a prefix of another and treats null bytes specially).
 	//
 	// It also maintains a plain sorted list of the same set of keys and asserts
-	// that iterating from some random key to the end using LowerBound produces
-	// the same list as filtering all sorted keys that are lower.
+	// that iterating from some random key to the beginning using ReverseLowerBound
+	// produces the same list as filtering all sorted keys that are bigger.
 
 	radixAddAndScan := func(newKey, searchKey readableString) []string {
 		// Append a null byte

--- a/reverse_iter_test.go
+++ b/reverse_iter_test.go
@@ -1,0 +1,148 @@
+package iradix
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestReverseIterator_SeekReverseLowerBound(t *testing.T) {
+	r := New()
+	keys := []string{"001", "002", "005", "010", "200", "201"}
+	for _, k := range keys {
+		r, _, _ = r.Insert([]byte(k), nil)
+	}
+
+	cases := []struct {
+		name            string
+		prefix          string
+		want            string
+		wantFromNonRoot string
+	}{
+		{
+			name:   "exact match",
+			prefix: "002",
+			want:   "002",
+		},
+		{
+			name:   "between leaf nodes",
+			prefix: "003",
+			want:   "002",
+		},
+		{
+			name:   "between non-leaf nodes",
+			prefix: "100",
+			want:   "010",
+		},
+		{
+			name:   "outbound low",
+			prefix: "/", // the character '/' comes before '0' in ASCII
+			want:   "",
+		},
+		{
+			name:            "outbound high",
+			prefix:          "300",
+			want:            "201",
+			wantFromNonRoot: "010",
+		},
+		{
+			name:   "long prefix low",
+			prefix: "0010",
+			want:   "",
+		},
+		{
+			name:            "long prefix high",
+			prefix:          "2010",
+			want:            "200",
+			wantFromNonRoot: "010",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("from_root/%s", c.name), func(t *testing.T) {
+			it := r.Root().ReverseIterator()
+			it.SeekReverseLowerBound([]byte(c.prefix))
+			got, _, _ := it.Previous()
+
+			if string(got) != c.want {
+				t.Errorf("prefix %s seek failed: got: %s, want: %s", c.prefix, got, c.want)
+			}
+		})
+
+		t.Run(fmt.Sprintf("from_non_root/%s", c.name), func(t *testing.T) {
+			n := r.Root().edges[0].node
+			it := n.ReverseIterator()
+			it.SeekReverseLowerBound([]byte(c.prefix))
+			got, _, _ := it.Previous()
+
+			want := c.wantFromNonRoot
+			if want == "" {
+				want = c.want
+			}
+
+			if string(got) != want {
+				t.Errorf("prefix %s seek failed: got: %s, want: %s", c.prefix, got, want)
+			}
+		})
+	}
+}
+
+func TestReverseIterator_SeekPrefix(t *testing.T) {
+	r := New()
+	keys := []string{"001", "002", "005", "010", "100"}
+	for _, k := range keys {
+		r, _, _ = r.Insert([]byte(k), nil)
+	}
+
+	cases := []struct {
+		name         string
+		prefix       string
+		expectResult bool
+	}{
+		{
+			name:         "existing prefix",
+			prefix:       "005",
+			expectResult: true,
+		},
+		{
+			name:         "non-existing prefix",
+			prefix:       "2",
+			expectResult: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			it := r.Root().ReverseIterator()
+			it.SeekPrefix([]byte(c.prefix))
+
+			if c.expectResult && it.i.node == nil {
+				t.Errorf("expexted prefix %s to exist", c.prefix)
+				return
+			}
+
+			if !c.expectResult && it.i.node != nil {
+				t.Errorf("unexpected node for prefix '%s'", c.prefix)
+				return
+			}
+		})
+	}
+}
+
+func TestReverseIterator_Previous(t *testing.T) {
+	r := New()
+	keys := []string{"001", "002", "005", "010", "100"}
+	for _, k := range keys {
+		r, _, _ = r.Insert([]byte(k), nil)
+	}
+
+	it := r.Root().ReverseIterator()
+
+	for i := len(keys) - 1; i >= 0; i-- {
+		got, _, _ := it.Previous()
+		want := keys[i]
+
+		if string(got) != want {
+			t.Errorf("got: %v, want: %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
This PR implements reverse tree traversal. 

It introduces a new type of `Iterator` called `ReverseIterator` that can move through a tree in reverse order using the `Previous()` and `SeekReverseLowerBound()` methods. 

It also adds a new `WalkBackwards()` method to `Node` that works the same way as `Walk()` but in reverse, going from the largest to the lowest values.