### PR TITLE
fix: iterate lower bound may panic if search with the same prefix on keys

### DIFF
--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1551,7 +1551,10 @@ func TestIterateLowerBound(t *testing.T) {
 		"zap",
 		"zip",
 	}
-
+	specialKeys := []string{
+		string([]byte{1, 0, 1, 0, 0}),
+		string([]byte{1, 0, 1, 0, 1, 0}),
+	}
 	type exp struct {
 		keys   []string
 		search string
@@ -1664,6 +1667,36 @@ func TestIterateLowerBound(t *testing.T) {
 			[]string{"aaaba", "aabaa", "aabab", "aabcb", "aacca", "abaaa", "abacb", "abbcb", "abcaa", "abcba", "abcbb", "acaaa", "acaab", "acaac", "acaca", "acacb", "acbaa", "acbbb", "acbcc", "accca", "babaa", "babcc", "bbaaa", "bbacc", "bbbab", "bbbac", "bbbcc", "bbcab", "bbcca", "bbccc", "bcaac", "bcbca", "bcbcc", "bccac", "bccbc", "bccca", "caaab", "caacc", "cabac", "cabbb", "cabbc", "cabcb", "cacac", "cacbc", "cacca", "cbaba", "cbabb", "cbabc", "cbbaa", "cbbab", "cbbbc", "cbcbb", "cbcbc", "cbcca", "ccaaa", "ccabc", "ccaca", "ccacc", "ccbac", "cccaa", "cccac", "cccca"},
 			"cbacb",
 			[]string{"cbbaa", "cbbab", "cbbbc", "cbcbb", "cbcbc", "cbcca", "ccaaa", "ccabc", "ccaca", "ccacc", "ccbac", "cccaa", "cccac", "cccca"},
+		},
+		{
+			specialKeys,
+			"",
+			specialKeys,
+		},
+		{
+			specialKeys,
+			specialKeys[0][:4],
+			specialKeys,
+		},
+		{
+			specialKeys,
+			specialKeys[0],
+			specialKeys,
+		},
+		{
+			specialKeys,
+			specialKeys[1][:5],
+			[]string{specialKeys[1]},
+		},
+		{
+			specialKeys,
+			specialKeys[1],
+			[]string{specialKeys[1]},
+		},
+		{
+			specialKeys,
+			specialKeys[1] + "0",
+			[]string{},
 		},
 	}
 

--- a/iter.go
+++ b/iter.go
@@ -20,7 +20,7 @@ func (i *Iterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
 	watch = n.mutateCh
 	search := prefix
 	for {
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			i.node = n
 			return
@@ -132,6 +132,17 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 			search = search[len(n.prefix):]
 		}
 
+		// Check for key exhaustion
+		if len(search) == 0 {
+			// Prefix is same with the search key and not leaf node, that means the lower bound is greater than the search
+			// and from now on we need to follow the minimum path to the smallest
+			// leaf under this subtree.
+			n = i.recurseMin(n)
+			if n != nil {
+				found(n)
+			}
+			return
+		}
 		// Otherwise, take the lower bound next edge.
 		idx, lbNode := n.getLowerBoundEdge(search[0])
 		if lbNode == nil {


### PR DESCRIPTION
this should fix the issue #28 