### PR TITLE
Fix SeekLowerBound where tree contains keys that are prefixes of each other

### DIFF
--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1735,7 +1735,7 @@ type readableString string
 
 func (s readableString) Generate(rand *rand.Rand, size int) reflect.Value {
 	// Pick a random string from a limited alphabet that makes it easy to read the
-	// failure cases. Also never includes a null byte as we don't support that.
+	// failure cases.
 	const letters = "abcdefghijklmnopqrstuvwxyz/-_0123456789"
 
 	b := make([]byte, size)
@@ -1757,7 +1757,6 @@ func TestIterateLowerBoundFuzz(t *testing.T) {
 	// the same list as filtering all sorted keys that are lower.
 
 	radixAddAndScan := func(newKey, searchKey readableString) []string {
-		// Append a null byte
 		r, _, _ = r.Insert([]byte(newKey), nil)
 
 		// Now iterate the tree from searchKey to the end
@@ -1769,7 +1768,6 @@ func TestIterateLowerBoundFuzz(t *testing.T) {
 			if !ok {
 				break
 			}
-			// Strip the null byte and append to result set
 			result = append(result, string(key))
 		}
 		return result

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1532,29 +1532,30 @@ func TestLenTxn(t *testing.T) {
 	}
 }
 
-// these should be defined in order
-var fixedLenKeys = []string{
-	"00000",
-	"00001",
-	"00004",
-	"00010",
-	"00020",
-	"20020",
-}
-
-// these should be defined in order
-var mixedLenKeys = []string{
-	"a1",
-	"abc",
-	"barbazboo",
-	"f",
-	"foo",
-	"found",
-	"zap",
-	"zip",
-}
-
 func TestIterateLowerBound(t *testing.T) {
+
+	// these should be defined in order
+	var fixedLenKeys = []string{
+		"00000",
+		"00001",
+		"00004",
+		"00010",
+		"00020",
+		"20020",
+	}
+
+	// these should be defined in order
+	var mixedLenKeys = []string{
+		"a1",
+		"abc",
+		"barbazboo",
+		"f",
+		"foo",
+		"found",
+		"zap",
+		"zip",
+	}
+
 	type exp struct {
 		keys   []string
 		search string

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1532,26 +1532,29 @@ func TestLenTxn(t *testing.T) {
 	}
 }
 
+// these should be defined in order
+var fixedLenKeys = []string{
+	"00000",
+	"00001",
+	"00004",
+	"00010",
+	"00020",
+	"20020",
+}
+
+// these should be defined in order
+var mixedLenKeys = []string{
+	"a1",
+	"abc",
+	"barbazboo",
+	"f",
+	"foo",
+	"found",
+	"zap",
+	"zip",
+}
+
 func TestIterateLowerBound(t *testing.T) {
-	fixedLenKeys := []string{
-		"00000",
-		"00001",
-		"00004",
-		"00010",
-		"00020",
-		"20020",
-	}
-
-	mixedLenKeys := []string{
-		"a1",
-		"abc",
-		"barbazboo",
-		"foo",
-		"found",
-		"zap",
-		"zip",
-	}
-
 	type exp struct {
 		keys   []string
 		search string
@@ -1562,7 +1565,8 @@ func TestIterateLowerBound(t *testing.T) {
 			fixedLenKeys,
 			"00000",
 			fixedLenKeys,
-		}, {
+		},
+		{
 			fixedLenKeys,
 			"00003",
 			[]string{
@@ -1571,7 +1575,8 @@ func TestIterateLowerBound(t *testing.T) {
 				"00020",
 				"20020",
 			},
-		}, {
+		},
+		{
 			fixedLenKeys,
 			"00010",
 			[]string{
@@ -1579,64 +1584,77 @@ func TestIterateLowerBound(t *testing.T) {
 				"00020",
 				"20020",
 			},
-		}, {
+		},
+		{
 			fixedLenKeys,
 			"20000",
 			[]string{
 				"20020",
 			},
-		}, {
+		},
+		{
 			fixedLenKeys,
 			"20020",
 			[]string{
 				"20020",
 			},
-		}, {
+		},
+		{
 			fixedLenKeys,
 			"20022",
 			[]string{},
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"A", // before all lower case letters
 			mixedLenKeys,
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"a1",
 			mixedLenKeys,
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"b",
 			[]string{
 				"barbazboo",
+				"f",
 				"foo",
 				"found",
 				"zap",
 				"zip",
 			},
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"bar",
 			[]string{
 				"barbazboo",
+				"f",
 				"foo",
 				"found",
 				"zap",
 				"zip",
 			},
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"barbazboo0",
 			[]string{
+				"f",
 				"foo",
 				"found",
 				"zap",
 				"zip",
 			},
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"zippy",
 			[]string{},
-		}, {
+		},
+		{
 			mixedLenKeys,
 			"zi",
 			[]string{
@@ -1674,7 +1692,8 @@ func TestIterateLowerBound(t *testing.T) {
 			[]string{"foo", "food"},
 		},
 
-		// We also support the empty key as a valid key to insert and search for.
+		// We also support the empty key (which is a prefix of every other key) as a
+		// valid key to insert and search for.
 		{
 			[]string{"f", "fo", "foo", "food", "bug", ""},
 			"foo",
@@ -1689,6 +1708,14 @@ func TestIterateLowerBound(t *testing.T) {
 			[]string{"f", "bug", "xylophone"},
 			"",
 			[]string{"bug", "f", "xylophone"},
+		},
+
+		// This is a case we realized we were not covering while fixing
+		// SeekReverseLowerBound and could panic before.
+		{
+			[]string{"bar", "foo00", "foo11"},
+			"foo",
+			[]string{"foo00", "foo11"},
 		},
 	}
 

--- a/iter.go
+++ b/iter.go
@@ -115,12 +115,8 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 		}
 
 		// Prefix is equal, we are still heading for an exact match. If this is a
-		// leaf we're done.
-		if n.leaf != nil {
-			if bytes.Compare(n.leaf.key, key) < 0 {
-				i.node = nil
-				return
-			}
+		// leaf and an exact match we're done.
+		if n.leaf != nil && bytes.Equal(n.leaf.key, key) {
 			found(n)
 			return
 		}

--- a/iter.go
+++ b/iter.go
@@ -60,10 +60,13 @@ func (i *Iterator) recurseMin(n *Node) *Node {
 	if n.leaf != nil {
 		return n
 	}
-	if len(n.edges) > 0 {
+	nEdges := len(n.edges)
+	if nEdges > 1 {
 		// Add all the other edges to the stack (the min node will be added as
 		// we recurse)
 		i.stack = append(i.stack, n.edges[1:])
+	}
+	if nEdges > 0 {
 		return i.recurseMin(n.edges[0].node)
 	}
 	// Shouldn't be possible

--- a/reverse_iter.go
+++ b/reverse_iter.go
@@ -66,9 +66,9 @@ func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
 	found := func(n *Node) {
 		ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
 		// We need to mark this node as expanded in advance too otherwise the
-		// iterator will attempt to walk all of it's children even though they are
+		// iterator will attempt to walk all of its children even though they are
 		// greater than the lower bound we have found. We've expanded it in the
-		// sense that all of it's children that we want to walk are already in the
+		// sense that all of its children that we want to walk are already in the
 		// stack (i.e. none of them).
 		ri.expandedParents[n] = struct{}{}
 	}
@@ -90,7 +90,7 @@ func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
 			// tree. So we need to follow the maximum path in this subtree to find it.
 			// Note that this is exactly what the iterator will already do if it find
 			// a node in the stack that has _not_ been marked as expanded so in this
-			// one case we don't call `found` and just let the iterator do it's
+			// one case we don't call `found` and just let the iterator do its
 			// expansion and recursion through all the children.
 			ri.i.node = n
 			ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
@@ -118,7 +118,7 @@ func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
 			}
 
 			// It's not so this node's leaf value must be lower and could still be a
-			// valide contender for reverse lower bound.
+			// valid contender for reverse lower bound.
 
 			// If it has no children then we are also done.
 			if len(n.edges) == 0 {
@@ -130,11 +130,11 @@ func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
 			// Finally, this leaf is internal (has children) so we'll keep searching,
 			// but we need to add it to the iterator's stack since it has a leaf value
 			// that needs to be iterated over. It needs to be added to the stack
-			// before it's children below as it comes first.
+			// before its children below as it comes first.
 			ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
-			// We also need to mark it as expanded since we'll be adding any of it's
+			// We also need to mark it as expanded since we'll be adding any of its
 			// relevant children below and so don't want the iterator to re-add them
-			// on it's way back up the stack.
+			// on its way back up the stack.
 			ri.expandedParents[n] = struct{}{}
 		}
 
@@ -234,7 +234,7 @@ func (ri *ReverseIterator) Previous() ([]byte, interface{}, bool) {
 			return elem.leaf.key, elem.leaf.val, true
 		}
 
-		// it's not a leaf so keep walking the stack to find the previous leafq
+		// it's not a leaf so keep walking the stack to find the previous leaf
 	}
 	return nil, nil, false
 }

--- a/reverse_iter.go
+++ b/reverse_iter.go
@@ -83,16 +83,15 @@ func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
 		}
 
 		if prefixCmp < 0 {
-			// Prefix is smaller than search prefix, that means there is no lower
-			// bound. But we are looking in reverse, so the reverse lower bound will
-			// be the largest leaf under this subtree, since it is the value that
-			// would come right before the current search prefix if it were in the
-			// tree. So we need to follow the maximum path in this subtree to find it.
-			// Note that this is exactly what the iterator will already do if it find
-			// a node in the stack that has _not_ been marked as expanded so in this
-			// one case we don't call `found` and just let the iterator do its
-			// expansion and recursion through all the children.
-			ri.i.node = n
+			// Prefix is smaller than search prefix, that means there is no exact
+			// match for the search key. But we are looking in reverse, so the reverse
+			// lower bound will be the largest leaf under this subtree, since it is
+			// the value that would come right before the current search key if it
+			// were in the tree. So we need to follow the maximum path in this subtree
+			// to find it. Note that this is exactly what the iterator will already do
+			// if it finds a node in the stack that has _not_ been marked as expanded
+			// so in this one case we don't call `found` and instead let the iterator
+			// do the expansion and recursion through all the children.
 			ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
 			return
 		}

--- a/reverse_iter.go
+++ b/reverse_iter.go
@@ -244,7 +244,7 @@ func (ri *ReverseIterator) Previous() ([]byte, interface{}, bool) {
 			return elem.leaf.key, elem.leaf.val, true
 		}
 
-		// it's not a leaf so keep walking the stack to find the previous leaf
+		// it's not a leaf so keep walking the stack to find the previous leafq
 	}
 	return nil, nil, false
 }

--- a/reverse_iter_test.go
+++ b/reverse_iter_test.go
@@ -68,13 +68,26 @@ func TestReverseIterator_SeekReverseLowerBoundFuzz(t *testing.T) {
 
 func TestReverseIterator_SeekLowerBound(t *testing.T) {
 
-	var revFixedLenKeys, revMixedLenKeys []string
-
-	for i := len(fixedLenKeys) - 1; i >= 0; i-- {
-		revFixedLenKeys = append(revFixedLenKeys, fixedLenKeys[i])
+	// these should be defined in order
+	var fixedLenKeys = []string{
+		"20020",
+		"00020",
+		"00010",
+		"00004",
+		"00001",
+		"00000",
 	}
-	for i := len(mixedLenKeys) - 1; i >= 0; i-- {
-		revMixedLenKeys = append(revMixedLenKeys, mixedLenKeys[i])
+
+	// these should be defined in order
+	var mixedLenKeys = []string{
+		"zip",
+		"zap",
+		"found",
+		"foo",
+		"f",
+		"barbazboo",
+		"abc",
+		"a1",
 	}
 
 	type exp struct {
@@ -86,7 +99,7 @@ func TestReverseIterator_SeekLowerBound(t *testing.T) {
 		{
 			fixedLenKeys,
 			"20020",
-			revFixedLenKeys,
+			fixedLenKeys,
 		},
 		{
 			fixedLenKeys,
@@ -124,12 +137,12 @@ func TestReverseIterator_SeekLowerBound(t *testing.T) {
 		{
 			mixedLenKeys,
 			"{", // after all lower case letters
-			revMixedLenKeys,
+			mixedLenKeys,
 		},
 		{
 			mixedLenKeys,
 			"zip",
-			revMixedLenKeys,
+			mixedLenKeys,
 		},
 		{
 			mixedLenKeys,


### PR DESCRIPTION
Fixes #37 #28.

This seems like a trivial case to miss however it stemmed from some confusion (on my part) about whether iradix was ever intended to support keys that were prefixes. It's a long story and I don't even recall exactly why I thought this was the case now given that every other operation on iradix supports this and most even include this case in their test examples. We even had it in the README example!

But some combination of:
 - I was working at the time on a related radix tree that did have the assumption of null-terminated keys
 - hashicorp/go-memdb always null terminates even for simpler string indexes

Anyway the fix is simple and the examples now pass.

In addition the fuzz test (which explicitly used the null-termination trick to never trigger this assuming it was necessary in general) now passes without null terminating keys every time I've run it.