### PR TITLE
v2: use generics to enforce type invariants   

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-go-immutable-radix [![CircleCI](https://circleci.com/gh/hashicorp/go-immutable-radix/tree/master.svg?style=svg)](https://circleci.com/gh/hashicorp/go-immutable-radix/tree/master)
+go-immutable-radix [![Run CI Tests](https://github.com/hashicorp/go-immutable-radix/actions/workflows/ci.yaml/badge.svg)](https://github.com/hashicorp/go-immutable-radix/actions/workflows/ci.yaml)
 =========
 
 Provides the `iradix` package that implements an immutable [radix tree](http://en.wikipedia.org/wiki/Radix_tree).
@@ -15,6 +15,13 @@ in a more efficient manner than performing each operation one at a time.
 
 For a mutable variant, see [go-radix](https://github.com/armon/go-radix).
 
+V2
+==
+
+The v2 of go-immutable-radix introduces generics to improve compile-time type
+safety for users of the package. The module name for v2 is
+`github.com/hashicorp/go-immutable-radix/v2`.
+
 Documentation
 =============
 
@@ -27,7 +34,7 @@ Below is a simple example of usage
 
 ```go
 // Create a tree
-r := iradix.New()
+r := iradix.New[int]()
 r, _, _ = r.Insert([]byte("foo"), 1)
 r, _, _ = r.Insert([]byte("bar"), 2)
 r, _, _ = r.Insert([]byte("foobar"), 2)
@@ -43,7 +50,7 @@ Here is an example of performing a range scan of the keys.
 
 ```go
 // Create a tree
-r := iradix.New()
+r := iradix.New[int]()
 r, _, _ = r.Insert([]byte("001"), 1)
 r, _, _ = r.Insert([]byte("002"), 2)
 r, _, _ = r.Insert([]byte("005"), 5)
@@ -54,10 +61,10 @@ r, _, _ = r.Insert([]byte("100"), 10)
 it := r.Root().Iterator()
 it.SeekLowerBound([]byte("003"))
 for key, _, ok := it.Next(); ok; key, _, ok = it.Next() {
-  if key >= "050" {
+  if string(key) >= "050" {
       break
   }
-  fmt.Println(key)
+  fmt.Println(string(key))
 }
 // Output:
 //  005

--- a/edges.go
+++ b/edges.go
@@ -2,20 +2,20 @@ package iradix
 
 import "sort"
 
-type edges []edge
+type edges[T any] []edge[T]
 
-func (e edges) Len() int {
+func (e edges[T]) Len() int {
 	return len(e)
 }
 
-func (e edges) Less(i, j int) bool {
+func (e edges[T]) Less(i, j int) bool {
 	return e[i].label < e[j].label
 }
 
-func (e edges) Swap(i, j int) {
+func (e edges[T]) Swap(i, j int) {
 	e[i], e[j] = e[j], e[i]
 }
 
-func (e edges) Sort() {
+func (e edges[T]) Sort() {
 	sort.Sort(e)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/hashicorp/go-immutable-radix
+module github.com/hashicorp/go-immutable-radix/v2
 
 go 1.18
 
 require (
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/hashicorp/golang-lru v0.5.4
+	golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/go-immutable-radix/v2
 go 1.18
 
 require (
-	github.com/hashicorp/go-uuid v1.0.0
-	github.com/hashicorp/golang-lru v0.5.4
-	golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983
+	github.com/hashicorp/go-uuid v1.0.3
+	github.com/hashicorp/golang-lru/v2 v2.0.0
+	golang.org/x/exp v0.0.0-20221215174704-0915cd710c24
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/go-immutable-radix
 
+go 1.18
+
 require (
 	github.com/hashicorp/go-uuid v1.0.0
-	github.com/hashicorp/golang-lru v0.5.0
+	github.com/hashicorp/golang-lru v0.5.4
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCS
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983 h1:sUweFwmLOje8KNfXAVqGGAsmgJ/F8jJ6wBLJDt4BTKY=
-golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/golang-lru/v2 v2.0.0 h1:Lf+9eD8m5pncvHAOCQj49GSN6aQI8XGfI5OpXNkoWaA=
+github.com/hashicorp/golang-lru/v2 v2.0.0/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+golang.org/x/exp v0.0.0-20221215174704-0915cd710c24 h1:6w3iSY8IIkp5OQtbYj8NeuKG1jS9d+kYaubXqsoOiQ8=
+golang.org/x/exp v0.0.0-20221215174704-0915cd710c24/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
-github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983 h1:sUweFwmLOje8KNfXAVqGGAsmgJ/F8jJ6wBLJDt4BTKY=
+golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=

--- a/iradix.go
+++ b/iradix.go
@@ -23,15 +23,15 @@ const (
 // hash map is prefix-based lookups and ordered iteration. The immutability
 // means that it is safe to concurrently read from a Tree without any
 // coordination.
-type Tree struct {
-	root *Node
+type Tree[T any] struct {
+	root *Node[T]
 	size int
 }
 
 // New returns an empty Tree
-func New() *Tree {
-	t := &Tree{
-		root: &Node{
+func New[T any]() *Tree[T] {
+	t := &Tree[T]{
+		root: &Node[T]{
 			mutateCh: make(chan struct{}),
 		},
 	}
@@ -39,20 +39,20 @@ func New() *Tree {
 }
 
 // Len is used to return the number of elements in the tree
-func (t *Tree) Len() int {
+func (t *Tree[T]) Len() int {
 	return t.size
 }
 
 // Txn is a transaction on the tree. This transaction is applied
 // atomically and returns a new tree when committed. A transaction
 // is not thread safe, and should only be used by a single goroutine.
-type Txn struct {
+type Txn[T any] struct {
 	// root is the modified root for the transaction.
-	root *Node
+	root *Node[T]
 
 	// snap is a snapshot of the root node for use if we have to run the
 	// slow notify algorithm.
-	snap *Node
+	snap *Node[T]
 
 	// size tracks the size of the tree as it is modified during the
 	// transaction.
@@ -77,8 +77,8 @@ type Txn struct {
 }
 
 // Txn starts a new transaction that can be used to mutate the tree
-func (t *Tree) Txn() *Txn {
-	txn := &Txn{
+func (t *Tree[T]) Txn() *Txn[T] {
+	txn := &Txn[T]{
 		root: t.root,
 		snap: t.root,
 		size: t.size,
@@ -88,11 +88,11 @@ func (t *Tree) Txn() *Txn {
 
 // Clone makes an independent copy of the transaction. The new transaction
 // does not track any nodes and has TrackMutate turned off. The cloned transaction will contain any uncommitted writes in the original transaction but further mutations to either will be independent and result in different radix trees on Commit. A cloned transaction may be passed to another goroutine and mutated there independently however each transaction may only be mutated in a single thread.
-func (t *Txn) Clone() *Txn {
+func (t *Txn[T]) Clone() *Txn[T] {
 	// reset the writable node cache to avoid leaking future writes into the clone
 	t.writable = nil
 
-	txn := &Txn{
+	txn := &Txn[T]{
 		root: t.root,
 		snap: t.snap,
 		size: t.size,
@@ -103,7 +103,7 @@ func (t *Txn) Clone() *Txn {
 // TrackMutate can be used to toggle if mutations are tracked. If this is enabled
 // then notifications will be issued for affected internal nodes and leaves when
 // the transaction is committed.
-func (t *Txn) TrackMutate(track bool) {
+func (t *Txn[T]) TrackMutate(track bool) {
 	t.trackMutate = track
 }
 
@@ -111,7 +111,7 @@ func (t *Txn) TrackMutate(track bool) {
 // overflow flag if we can no longer track any more. This limits the amount of
 // state that will accumulate during a transaction and we have a slower algorithm
 // to switch to if we overflow.
-func (t *Txn) trackChannel(ch chan struct{}) {
+func (t *Txn[T]) trackChannel(ch chan struct{}) {
 	// In overflow, make sure we don't store any more objects.
 	if t.trackOverflow {
 		return
@@ -143,7 +143,7 @@ func (t *Txn) trackChannel(ch chan struct{}) {
 // modified during the course of the transaction, it is used in-place. Set
 // forLeafUpdate to true if you are getting a write node to update the leaf,
 // which will set leaf mutation tracking appropriately as well.
-func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
+func (t *Txn[T]) writeNode(n *Node[T], forLeafUpdate bool) *Node[T] {
 	// Ensure the writable set exists.
 	if t.writable == nil {
 		lru, err := simplelru.NewLRU(defaultModifiedCache, nil)
@@ -179,7 +179,7 @@ func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
 	// safe to replace this leaf with another after you get your node for
 	// writing. You MUST replace it, because the channel associated with
 	// this leaf will be closed when this transaction is committed.
-	nc := &Node{
+	nc := &Node[T]{
 		mutateCh: make(chan struct{}),
 		leaf:     n.leaf,
 	}
@@ -188,7 +188,7 @@ func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
 		copy(nc.prefix, n.prefix)
 	}
 	if len(n.edges) != 0 {
-		nc.edges = make([]edge, len(n.edges))
+		nc.edges = make([]edge[T], len(n.edges))
 		copy(nc.edges, n.edges)
 	}
 
@@ -199,7 +199,7 @@ func (t *Txn) writeNode(n *Node, forLeafUpdate bool) *Node {
 
 // Visit all the nodes in the tree under n, and add their mutateChannels to the transaction
 // Returns the size of the subtree visited
-func (t *Txn) trackChannelsAndCount(n *Node) int {
+func (t *Txn[T]) trackChannelsAndCount(n *Node[T]) int {
 	// Count only leaf nodes
 	leaves := 0
 	if n.leaf != nil {
@@ -224,7 +224,7 @@ func (t *Txn) trackChannelsAndCount(n *Node) int {
 
 // mergeChild is called to collapse the given node with its child. This is only
 // called when the given node is not a leaf and has a single edge.
-func (t *Txn) mergeChild(n *Node) {
+func (t *Txn[T]) mergeChild(n *Node[T]) {
 	// Mark the child node as being mutated since we are about to abandon
 	// it. We don't need to mark the leaf since we are retaining it if it
 	// is there.
@@ -238,7 +238,7 @@ func (t *Txn) mergeChild(n *Node) {
 	n.prefix = concat(n.prefix, child.prefix)
 	n.leaf = child.leaf
 	if len(child.edges) != 0 {
-		n.edges = make([]edge, len(child.edges))
+		n.edges = make([]edge[T], len(child.edges))
 		copy(n.edges, child.edges)
 	} else {
 		n.edges = nil
@@ -246,10 +246,12 @@ func (t *Txn) mergeChild(n *Node) {
 }
 
 // insert does a recursive insertion
-func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface{}, bool) {
+func (t *Txn[T]) insert(n *Node[T], k, search []byte, v T) (*Node[T], T, bool) {
+	var zero T
+
 	// Handle key exhaustion
 	if len(search) == 0 {
-		var oldVal interface{}
+		var oldVal T
 		didUpdate := false
 		if n.isLeaf() {
 			oldVal = n.leaf.val
@@ -257,7 +259,7 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 		}
 
 		nc := t.writeNode(n, true)
-		nc.leaf = &leafNode{
+		nc.leaf = &leafNode[T]{
 			mutateCh: make(chan struct{}),
 			key:      k,
 			val:      v,
@@ -270,11 +272,11 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 
 	// No edge, create one
 	if child == nil {
-		e := edge{
+		e := edge[T]{
 			label: search[0],
-			node: &Node{
+			node: &Node[T]{
 				mutateCh: make(chan struct{}),
-				leaf: &leafNode{
+				leaf: &leafNode[T]{
 					mutateCh: make(chan struct{}),
 					key:      k,
 					val:      v,
@@ -284,7 +286,7 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 		}
 		nc := t.writeNode(n, false)
 		nc.addEdge(e)
-		return nc, nil, false
+		return nc, zero, false
 	}
 
 	// Determine longest prefix of the search key on match
@@ -302,25 +304,25 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 
 	// Split the node
 	nc := t.writeNode(n, false)
-	splitNode := &Node{
+	splitNode := &Node[T]{
 		mutateCh: make(chan struct{}),
 		prefix:   search[:commonPrefix],
 	}
-	nc.replaceEdge(edge{
+	nc.replaceEdge(edge[T]{
 		label: search[0],
 		node:  splitNode,
 	})
 
 	// Restore the existing child node
 	modChild := t.writeNode(child, false)
-	splitNode.addEdge(edge{
+	splitNode.addEdge(edge[T]{
 		label: modChild.prefix[commonPrefix],
 		node:  modChild,
 	})
 	modChild.prefix = modChild.prefix[commonPrefix:]
 
 	// Create a new leaf node
-	leaf := &leafNode{
+	leaf := &leafNode[T]{
 		mutateCh: make(chan struct{}),
 		key:      k,
 		val:      v,
@@ -330,23 +332,23 @@ func (t *Txn) insert(n *Node, k, search []byte, v interface{}) (*Node, interface
 	search = search[commonPrefix:]
 	if len(search) == 0 {
 		splitNode.leaf = leaf
-		return nc, nil, false
+		return nc, zero, false
 	}
 
 	// Create a new edge for the node
-	splitNode.addEdge(edge{
+	splitNode.addEdge(edge[T]{
 		label: search[0],
-		node: &Node{
+		node: &Node[T]{
 			mutateCh: make(chan struct{}),
 			leaf:     leaf,
 			prefix:   search,
 		},
 	})
-	return nc, nil, false
+	return nc, zero, false
 }
 
 // delete does a recursive deletion
-func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
+func (t *Txn[T]) delete(n *Node[T], search []byte) (*Node[T], *leafNode[T]) {
 	// Check for key exhaustion
 	if len(search) == 0 {
 		if !n.isLeaf() {
@@ -378,7 +380,7 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 
 	// Consume the search prefix
 	search = search[len(child.prefix):]
-	newChild, leaf := t.delete(n, child, search)
+	newChild, leaf := t.delete(child, search)
 	if newChild == nil {
 		return nil, nil
 	}
@@ -402,7 +404,7 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 }
 
 // delete does a recursive deletion
-func (t *Txn) deletePrefix(parent, n *Node, search []byte) (*Node, int) {
+func (t *Txn[T]) deletePrefix(n *Node[T], search []byte) (*Node[T], int) {
 	// Check for key exhaustion
 	if len(search) == 0 {
 		nc := t.writeNode(n, true)
@@ -428,7 +430,7 @@ func (t *Txn) deletePrefix(parent, n *Node, search []byte) (*Node, int) {
 	} else {
 		search = search[len(child.prefix):]
 	}
-	newChild, numDeletions := t.deletePrefix(n, child, search)
+	newChild, numDeletions := t.deletePrefix(child, search)
 	if newChild == nil {
 		return nil, 0
 	}
@@ -453,7 +455,7 @@ func (t *Txn) deletePrefix(parent, n *Node, search []byte) (*Node, int) {
 
 // Insert is used to add or update a given key. The return provides
 // the previous value and a bool indicating if any was set.
-func (t *Txn) Insert(k []byte, v interface{}) (interface{}, bool) {
+func (t *Txn[T]) Insert(k []byte, v T) (T, bool) {
 	newRoot, oldVal, didUpdate := t.insert(t.root, k, k, v)
 	if newRoot != nil {
 		t.root = newRoot
@@ -466,8 +468,9 @@ func (t *Txn) Insert(k []byte, v interface{}) (interface{}, bool) {
 
 // Delete is used to delete a given key. Returns the old value if any,
 // and a bool indicating if the key was set.
-func (t *Txn) Delete(k []byte) (interface{}, bool) {
-	newRoot, leaf := t.delete(nil, t.root, k)
+func (t *Txn[T]) Delete(k []byte) (T, bool) {
+	var zero T
+	newRoot, leaf := t.delete(t.root, k)
 	if newRoot != nil {
 		t.root = newRoot
 	}
@@ -475,13 +478,13 @@ func (t *Txn) Delete(k []byte) (interface{}, bool) {
 		t.size--
 		return leaf.val, true
 	}
-	return nil, false
+	return zero, false
 }
 
 // DeletePrefix is used to delete an entire subtree that matches the prefix
 // This will delete all nodes under that prefix
-func (t *Txn) DeletePrefix(prefix []byte) bool {
-	newRoot, numDeletions := t.deletePrefix(nil, t.root, prefix)
+func (t *Txn[T]) DeletePrefix(prefix []byte) bool {
+	newRoot, numDeletions := t.deletePrefix(t.root, prefix)
 	if newRoot != nil {
 		t.root = newRoot
 		t.size = t.size - numDeletions
@@ -494,25 +497,25 @@ func (t *Txn) DeletePrefix(prefix []byte) bool {
 // Root returns the current root of the radix tree within this
 // transaction. The root is not safe across insert and delete operations,
 // but can be used to read the current state during a transaction.
-func (t *Txn) Root() *Node {
+func (t *Txn[T]) Root() *Node[T] {
 	return t.root
 }
 
 // Get is used to lookup a specific key, returning
 // the value and if it was found
-func (t *Txn) Get(k []byte) (interface{}, bool) {
+func (t *Txn[T]) Get(k []byte) (T, bool) {
 	return t.root.Get(k)
 }
 
 // GetWatch is used to lookup a specific key, returning
 // the watch channel, value and if it was found
-func (t *Txn) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
+func (t *Txn[T]) GetWatch(k []byte) (<-chan struct{}, T, bool) {
 	return t.root.GetWatch(k)
 }
 
 // Commit is used to finalize the transaction and return a new tree. If mutation
 // tracking is turned on then notifications will also be issued.
-func (t *Txn) Commit() *Tree {
+func (t *Txn[T]) Commit() *Tree[T] {
 	nt := t.CommitOnly()
 	if t.trackMutate {
 		t.Notify()
@@ -522,8 +525,8 @@ func (t *Txn) Commit() *Tree {
 
 // CommitOnly is used to finalize the transaction and return a new tree, but
 // does not issue any notifications until Notify is called.
-func (t *Txn) CommitOnly() *Tree {
-	nt := &Tree{t.root, t.size}
+func (t *Txn[T]) CommitOnly() *Tree[T] {
+	nt := &Tree[T]{t.root, t.size}
 	t.writable = nil
 	return nt
 }
@@ -531,7 +534,7 @@ func (t *Txn) CommitOnly() *Tree {
 // slowNotify does a complete comparison of the before and after trees in order
 // to trigger notifications. This doesn't require any additional state but it
 // is very expensive to compute.
-func (t *Txn) slowNotify() {
+func (t *Txn[T]) slowNotify() {
 	snapIter := t.snap.rawIterator()
 	rootIter := t.root.rawIterator()
 	for snapIter.Front() != nil || rootIter.Front() != nil {
@@ -594,7 +597,7 @@ func (t *Txn) slowNotify() {
 // Notify is used along with TrackMutate to trigger notifications. This must
 // only be done once a transaction is committed via CommitOnly, and it is called
 // automatically by Commit.
-func (t *Txn) Notify() {
+func (t *Txn[T]) Notify() {
 	if !t.trackMutate {
 		return
 	}
@@ -617,7 +620,7 @@ func (t *Txn) Notify() {
 
 // Insert is used to add or update a given key. The return provides
 // the new tree, previous value and a bool indicating if any was set.
-func (t *Tree) Insert(k []byte, v interface{}) (*Tree, interface{}, bool) {
+func (t *Tree[T]) Insert(k []byte, v T) (*Tree[T], T, bool) {
 	txn := t.Txn()
 	old, ok := txn.Insert(k, v)
 	return txn.Commit(), old, ok
@@ -625,7 +628,7 @@ func (t *Tree) Insert(k []byte, v interface{}) (*Tree, interface{}, bool) {
 
 // Delete is used to delete a given key. Returns the new tree,
 // old value if any, and a bool indicating if the key was set.
-func (t *Tree) Delete(k []byte) (*Tree, interface{}, bool) {
+func (t *Tree[T]) Delete(k []byte) (*Tree[T], T, bool) {
 	txn := t.Txn()
 	old, ok := txn.Delete(k)
 	return txn.Commit(), old, ok
@@ -633,7 +636,7 @@ func (t *Tree) Delete(k []byte) (*Tree, interface{}, bool) {
 
 // DeletePrefix is used to delete all nodes starting with a given prefix. Returns the new tree,
 // and a bool indicating if the prefix matched any nodes
-func (t *Tree) DeletePrefix(k []byte) (*Tree, bool) {
+func (t *Tree[T]) DeletePrefix(k []byte) (*Tree[T], bool) {
 	txn := t.Txn()
 	ok := txn.DeletePrefix(k)
 	return txn.Commit(), ok
@@ -641,13 +644,13 @@ func (t *Tree) DeletePrefix(k []byte) (*Tree, bool) {
 
 // Root returns the root node of the tree which can be used for richer
 // query operations.
-func (t *Tree) Root() *Node {
+func (t *Tree[T]) Root() *Node[T] {
 	return t.root
 }
 
 // Get is used to lookup a specific key, returning
 // the value and if it was found
-func (t *Tree) Get(k []byte) (interface{}, bool) {
+func (t *Tree[T]) Get(k []byte) (T, bool) {
 	return t.root.Get(k)
 }
 

--- a/iradix.go
+++ b/iradix.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
 const (
@@ -63,7 +63,7 @@ type Txn[T any] struct {
 	// nodes for further writes and avoid unnecessary copies of nodes that
 	// have never been exposed outside the transaction. This will only hold
 	// up to defaultModifiedCache number of entries.
-	writable *simplelru.LRU
+	writable *simplelru.LRU[*Node[T], any]
 
 	// trackChannels is used to hold channels that need to be notified to
 	// signal mutation of the tree. This will only hold up to
@@ -146,7 +146,7 @@ func (t *Txn[T]) trackChannel(ch chan struct{}) {
 func (t *Txn[T]) writeNode(n *Node[T], forLeafUpdate bool) *Node[T] {
 	// Ensure the writable set exists.
 	if t.writable == nil {
-		lru, err := simplelru.NewLRU(defaultModifiedCache, nil)
+		lru, err := simplelru.NewLRU[*Node[T], any](defaultModifiedCache, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/node.go
+++ b/node.go
@@ -8,28 +8,28 @@ import (
 // WalkFn is used when walking the tree. Takes a
 // key and value, returning if iteration should
 // be terminated.
-type WalkFn func(k []byte, v interface{}) bool
+type WalkFn[T any] func(k []byte, v T) bool
 
 // leafNode is used to represent a value
-type leafNode struct {
+type leafNode[T any] struct {
 	mutateCh chan struct{}
 	key      []byte
-	val      interface{}
+	val      T
 }
 
 // edge is used to represent an edge node
-type edge struct {
+type edge[T any] struct {
 	label byte
-	node  *Node
+	node  *Node[T]
 }
 
 // Node is an immutable node in the radix tree
-type Node struct {
+type Node[T any] struct {
 	// mutateCh is closed if this node is modified
 	mutateCh chan struct{}
 
 	// leaf is used to store possible leaf
-	leaf *leafNode
+	leaf *leafNode[T]
 
 	// prefix is the common prefix we ignore
 	prefix []byte
@@ -37,14 +37,14 @@ type Node struct {
 	// Edges should be stored in-order for iteration.
 	// We avoid a fully materialized slice to save memory,
 	// since in most cases we expect to be sparse
-	edges edges
+	edges edges[T]
 }
 
-func (n *Node) isLeaf() bool {
+func (n *Node[T]) isLeaf() bool {
 	return n.leaf != nil
 }
 
-func (n *Node) addEdge(e edge) {
+func (n *Node[T]) addEdge(e edge[T]) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= e.label
@@ -56,7 +56,7 @@ func (n *Node) addEdge(e edge) {
 	}
 }
 
-func (n *Node) replaceEdge(e edge) {
+func (n *Node[T]) replaceEdge(e edge[T]) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= e.label
@@ -68,7 +68,7 @@ func (n *Node) replaceEdge(e edge) {
 	panic("replacing missing edge")
 }
 
-func (n *Node) getEdge(label byte) (int, *Node) {
+func (n *Node[T]) getEdge(label byte) (int, *Node[T]) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= label
@@ -79,7 +79,7 @@ func (n *Node) getEdge(label byte) (int, *Node) {
 	return -1, nil
 }
 
-func (n *Node) getLowerBoundEdge(label byte) (int, *Node) {
+func (n *Node[T]) getLowerBoundEdge(label byte) (int, *Node[T]) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= label
@@ -91,19 +91,19 @@ func (n *Node) getLowerBoundEdge(label byte) (int, *Node) {
 	return -1, nil
 }
 
-func (n *Node) delEdge(label byte) {
+func (n *Node[T]) delEdge(label byte) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= label
 	})
 	if idx < num && n.edges[idx].label == label {
 		copy(n.edges[idx:], n.edges[idx+1:])
-		n.edges[len(n.edges)-1] = edge{}
+		n.edges[len(n.edges)-1] = edge[T]{}
 		n.edges = n.edges[:len(n.edges)-1]
 	}
 }
 
-func (n *Node) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
+func (n *Node[T]) GetWatch(k []byte) (<-chan struct{}, T, bool) {
 	search := k
 	watch := n.mutateCh
 	for {
@@ -131,18 +131,19 @@ func (n *Node) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 			break
 		}
 	}
-	return watch, nil, false
+	var zero T
+	return watch, zero, false
 }
 
-func (n *Node) Get(k []byte) (interface{}, bool) {
+func (n *Node[T]) Get(k []byte) (T, bool) {
 	_, val, ok := n.GetWatch(k)
 	return val, ok
 }
 
 // LongestPrefix is like Get, but instead of an
 // exact match, it will return the longest prefix match.
-func (n *Node) LongestPrefix(k []byte) ([]byte, interface{}, bool) {
-	var last *leafNode
+func (n *Node[T]) LongestPrefix(k []byte) ([]byte, T, bool) {
+	var last *leafNode[T]
 	search := k
 	for {
 		// Look for a leaf node
@@ -150,7 +151,7 @@ func (n *Node) LongestPrefix(k []byte) ([]byte, interface{}, bool) {
 			last = n.leaf
 		}
 
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			break
 		}
@@ -171,11 +172,12 @@ func (n *Node) LongestPrefix(k []byte) ([]byte, interface{}, bool) {
 	if last != nil {
 		return last.key, last.val, true
 	}
-	return nil, nil, false
+	var zero T
+	return nil, zero, false
 }
 
 // Minimum is used to return the minimum value in the tree
-func (n *Node) Minimum() ([]byte, interface{}, bool) {
+func (n *Node[T]) Minimum() ([]byte, T, bool) {
 	for {
 		if n.isLeaf() {
 			return n.leaf.key, n.leaf.val, true
@@ -186,14 +188,15 @@ func (n *Node) Minimum() ([]byte, interface{}, bool) {
 			break
 		}
 	}
-	return nil, nil, false
+	var zero T
+	return nil, zero, false
 }
 
 // Maximum is used to return the maximum value in the tree
-func (n *Node) Maximum() ([]byte, interface{}, bool) {
+func (n *Node[T]) Maximum() ([]byte, T, bool) {
 	for {
 		if num := len(n.edges); num > 0 {
-			n = n.edges[num-1].node
+			n = n.edges[num-1].node // bug?
 			continue
 		}
 		if n.isLeaf() {
@@ -202,44 +205,45 @@ func (n *Node) Maximum() ([]byte, interface{}, bool) {
 			break
 		}
 	}
-	return nil, nil, false
+	var zero T
+	return nil, zero, false
 }
 
 // Iterator is used to return an iterator at
 // the given node to walk the tree
-func (n *Node) Iterator() *Iterator {
-	return &Iterator{node: n}
+func (n *Node[T]) Iterator() *Iterator[T] {
+	return &Iterator[T]{node: n}
 }
 
 // ReverseIterator is used to return an iterator at
 // the given node to walk the tree backwards
-func (n *Node) ReverseIterator() *ReverseIterator {
+func (n *Node[T]) ReverseIterator() *ReverseIterator[T] {
 	return NewReverseIterator(n)
 }
 
 // rawIterator is used to return a raw iterator at the given node to walk the
 // tree.
-func (n *Node) rawIterator() *rawIterator {
-	iter := &rawIterator{node: n}
+func (n *Node[T]) rawIterator() *rawIterator[T] {
+	iter := &rawIterator[T]{node: n}
 	iter.Next()
 	return iter
 }
 
 // Walk is used to walk the tree
-func (n *Node) Walk(fn WalkFn) {
+func (n *Node[T]) Walk(fn WalkFn[T]) {
 	recursiveWalk(n, fn)
 }
 
 // WalkBackwards is used to walk the tree in reverse order
-func (n *Node) WalkBackwards(fn WalkFn) {
+func (n *Node[T]) WalkBackwards(fn WalkFn[T]) {
 	reverseRecursiveWalk(n, fn)
 }
 
 // WalkPrefix is used to walk the tree under a prefix
-func (n *Node) WalkPrefix(prefix []byte, fn WalkFn) {
+func (n *Node[T]) WalkPrefix(prefix []byte, fn WalkFn[T]) {
 	search := prefix
 	for {
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			recursiveWalk(n, fn)
 			return
@@ -269,7 +273,7 @@ func (n *Node) WalkPrefix(prefix []byte, fn WalkFn) {
 // from the root down to a given leaf. Where WalkPrefix walks
 // all the entries *under* the given prefix, this walks the
 // entries *above* the given prefix.
-func (n *Node) WalkPath(path []byte, fn WalkFn) {
+func (n *Node[T]) WalkPath(path []byte, fn WalkFn[T]) {
 	search := path
 	for {
 		// Visit the leaf values if any
@@ -277,7 +281,7 @@ func (n *Node) WalkPath(path []byte, fn WalkFn) {
 			return
 		}
 
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			return
 		}
@@ -299,7 +303,7 @@ func (n *Node) WalkPath(path []byte, fn WalkFn) {
 
 // recursiveWalk is used to do a pre-order walk of a node
 // recursively. Returns true if the walk should be aborted
-func recursiveWalk(n *Node, fn WalkFn) bool {
+func recursiveWalk[T any](n *Node[T], fn WalkFn[T]) bool {
 	// Visit the leaf values if any
 	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
 		return true
@@ -317,7 +321,7 @@ func recursiveWalk(n *Node, fn WalkFn) bool {
 // reverseRecursiveWalk is used to do a reverse pre-order
 // walk of a node recursively. Returns true if the walk
 // should be aborted
-func reverseRecursiveWalk(n *Node, fn WalkFn) bool {
+func reverseRecursiveWalk[T any](n *Node[T], fn WalkFn[T]) bool {
 	// Visit the leaf values if any
 	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
 		return true

--- a/node_test.go
+++ b/node_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNodeWalk(t *testing.T) {
-	r := New()
+	r := New[any]()
 	keys := []string{"001", "002", "005", "010", "100"}
 	for _, k := range keys {
 		r, _, _ = r.Insert([]byte(k), nil)
@@ -13,7 +13,7 @@ func TestNodeWalk(t *testing.T) {
 
 	i := 0
 
-	r.Root().Walk(func(k []byte, _ interface{}) bool {
+	r.Root().Walk(func(k []byte, _ any) bool {
 		got := string(k)
 		want := keys[i]
 		if got != want {
@@ -30,7 +30,7 @@ func TestNodeWalk(t *testing.T) {
 }
 
 func TestNodeWalkBackwards(t *testing.T) {
-	r := New()
+	r := New[any]()
 	keys := []string{"001", "002", "005", "010", "100"}
 	for _, k := range keys {
 		r, _, _ = r.Insert([]byte(k), nil)
@@ -38,7 +38,7 @@ func TestNodeWalkBackwards(t *testing.T) {
 
 	i := len(keys) - 1
 
-	r.Root().WalkBackwards(func(k []byte, _ interface{}) bool {
+	r.Root().WalkBackwards(func(k []byte, _ any) bool {
 		got := string(k)
 		want := keys[i]
 		if got != want {

--- a/raw_iter.go
+++ b/raw_iter.go
@@ -3,15 +3,15 @@ package iradix
 // rawIterator visits each of the nodes in the tree, even the ones that are not
 // leaves. It keeps track of the effective path (what a leaf at a given node
 // would be called), which is useful for comparing trees.
-type rawIterator struct {
+type rawIterator[T any] struct {
 	// node is the starting node in the tree for the iterator.
-	node *Node
+	node *Node[T]
 
 	// stack keeps track of edges in the frontier.
-	stack []rawStackEntry
+	stack []rawStackEntry[T]
 
 	// pos is the current position of the iterator.
-	pos *Node
+	pos *Node[T]
 
 	// path is the effective path of the current iterator position,
 	// regardless of whether the current node is a leaf.
@@ -20,30 +20,30 @@ type rawIterator struct {
 
 // rawStackEntry is used to keep track of the cumulative common path as well as
 // its associated edges in the frontier.
-type rawStackEntry struct {
+type rawStackEntry[T any] struct {
 	path  string
-	edges edges
+	edges edges[T]
 }
 
 // Front returns the current node that has been iterated to.
-func (i *rawIterator) Front() *Node {
+func (i *rawIterator[T]) Front() *Node[T] {
 	return i.pos
 }
 
 // Path returns the effective path of the current node, even if it's not actually
 // a leaf.
-func (i *rawIterator) Path() string {
+func (i *rawIterator[T]) Path() string {
 	return i.path
 }
 
 // Next advances the iterator to the next node.
-func (i *rawIterator) Next() {
+func (i *rawIterator[T]) Next() {
 	// Initialize our stack if needed.
 	if i.stack == nil && i.node != nil {
-		i.stack = []rawStackEntry{
+		i.stack = []rawStackEntry[T]{
 			{
-				edges: edges{
-					edge{node: i.node},
+				edges: edges[T]{
+					edge[T]{node: i.node},
 				},
 			},
 		}
@@ -65,7 +65,7 @@ func (i *rawIterator) Next() {
 		// Push the edges onto the frontier.
 		if len(elem.edges) > 0 {
 			path := last.path + string(elem.prefix)
-			i.stack = append(i.stack, rawStackEntry{path, elem.edges})
+			i.stack = append(i.stack, rawStackEntry[T]{path, elem.edges})
 		}
 
 		i.pos = elem

--- a/reverse_iter_test.go
+++ b/reverse_iter_test.go
@@ -2,15 +2,16 @@ package iradix
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"testing"
 	"testing/quick"
+
+	"golang.org/x/exp/slices"
 )
 
 func TestReverseIterator_SeekReverseLowerBoundFuzz(t *testing.T) {
-	r := New()
-	set := []string{}
+	r := New[any]()
+	var set []string
 
 	// This specifies a property where each call adds a new random key to the radix
 	// tree.
@@ -24,7 +25,7 @@ func TestReverseIterator_SeekReverseLowerBoundFuzz(t *testing.T) {
 
 		// Now iterate the tree from searchKey to the beginning
 		it := r.Root().ReverseIterator()
-		result := []string{}
+		var result []string
 		it.SeekReverseLowerBound([]byte(searchKey))
 		for {
 			key, _, ok := it.Previous()
@@ -44,7 +45,7 @@ func TestReverseIterator_SeekReverseLowerBoundFuzz(t *testing.T) {
 		t.Logf("Current Set: %#v", set)
 		t.Logf("Search Key: %#v %v", searchKey, "" >= string(searchKey))
 
-		result := []string{}
+		var result []string
 		for i := len(set) - 1; i >= 0; i-- {
 			k := set[i]
 			// Check this is not a duplicate of the previous value we just included.
@@ -238,7 +239,7 @@ func TestReverseIterator_SeekLowerBound(t *testing.T) {
 
 	for idx, test := range cases {
 		t.Run(fmt.Sprintf("case%03d", idx), func(t *testing.T) {
-			r := New()
+			r := New[any]()
 
 			// Insert keys
 			for _, k := range test.keys {
@@ -257,7 +258,7 @@ func TestReverseIterator_SeekLowerBound(t *testing.T) {
 			iter.SeekReverseLowerBound([]byte(test.search))
 
 			// Consume all the keys
-			out := []string{}
+			var out []string
 			for {
 				key, _, ok := iter.Previous()
 				if !ok {
@@ -265,7 +266,7 @@ func TestReverseIterator_SeekLowerBound(t *testing.T) {
 				}
 				out = append(out, string(key))
 			}
-			if !reflect.DeepEqual(out, test.want) {
+			if !slices.Equal(test.want, out) {
 				t.Fatalf("mis-match: key=%s\n  got=%v\n  want=%v", test.search,
 					out, test.want)
 			}
@@ -274,7 +275,7 @@ func TestReverseIterator_SeekLowerBound(t *testing.T) {
 }
 
 func TestReverseIterator_SeekPrefix(t *testing.T) {
-	r := New()
+	r := New[any]()
 	keys := []string{"001", "002", "005", "010", "100"}
 	for _, k := range keys {
 		r, _, _ = r.Insert([]byte(k), nil)
@@ -319,7 +320,7 @@ func TestReverseIterator_SeekPrefixWatch(t *testing.T) {
 	key := []byte("key")
 
 	// Create tree
-	r := New()
+	r := New[any]()
 	r, _, _ = r.Insert(key, nil)
 
 	// Find mutate channel
@@ -341,7 +342,7 @@ func TestReverseIterator_SeekPrefixWatch(t *testing.T) {
 }
 
 func TestReverseIterator_Previous(t *testing.T) {
-	r := New()
+	r := New[any]()
 	keys := []string{"001", "002", "005", "010", "100"}
 	for _, k := range keys {
 		r, _, _ = r.Insert([]byte(k), nil)


### PR DESCRIPTION
This PR introduces a v2 of `go-immutable-radix`, centered on utilizing generics. 

The major version bump is necessary because although the package is now generic, the exported type signatures have changed to _be_ generic; rather than assuming `interface{}` in places.

- sets minimum Go version to 1.18
- module is bumped to `github.com/hashicorp/go-immutable-radix/v2`
- CI is swapped from Circle to GitHub Actions
- Exported types and their methods are now generic
- minor code lint fixes

Closes #42 
Closes #36

```golang
r := iradix.New[string]() // e.g.
```

**note:** if this gets merged, be sure to tag with `v2.0.0`


Adding some benchmarks (via [this harness](https://gist.github.com/shoenig/2933864c7419b8937a4cd0ac8d96d5a8)). I suspect in practice the performance difference is negligible - the differences here could just be luck with GC going one way or the other.

```
Work/go/iradix-bench 24s
➜ go run main.go 
Scenario   Type        Size           V1           V2        Delta      Pct
 insertion byte        1000   1.697583ms   1.140482ms   -557.101µs  -32.82%
 insertion byte       10000  11.958884ms   9.357029ms  -2.601855ms  -21.76%
 insertion byte      100000 105.298741ms 110.699253ms   5.400512ms    5.13%
 insertion byte     1000000 741.490742ms 733.548246ms  -7.942496ms   -1.07%
 insertion employee    1000   1.231465ms   1.193493ms    -37.972µs   -3.08%
 insertion employee   10000  13.319666ms  14.263141ms    943.475µs    7.08%
 insertion employee  100000 110.649808ms  98.866248ms  -11.78356ms  -10.65%
 insertion employee 1000000 748.178939ms 681.968127ms -66.210812ms   -8.85%
 insertion int64       1000    1.33419ms   1.126917ms   -207.273µs  -15.54%
 insertion int64      10000  10.679749ms  10.884198ms    204.449µs    1.91%
 insertion int64     100000 113.991954ms 113.522559ms   -469.395µs   -0.41%
 insertion int64    1000000 754.626542ms 723.907751ms -30.718791ms   -4.07%
 insertion string      1000    993.762µs    559.075µs   -434.687µs  -43.74%
 insertion string     10000   12.36633ms  11.791997ms   -574.333µs   -4.64%
 insertion string    100000  97.246453ms  99.044017ms   1.797564ms    1.85%
 insertion string   1000000 697.957946ms 656.948516ms  -41.00943ms   -5.88%
   iterate byte        1000     17.052µs     12.504µs     -4.548µs  -26.67%
   iterate byte       10000    312.355µs    192.366µs   -119.989µs  -38.41%
   iterate byte      100000   6.272204ms   6.321789ms     49.585µs    0.79%
   iterate byte     1000000  62.505377ms   60.94112ms  -1.564257ms   -2.50%
   iterate employee    1000      10.46µs     12.905µs      2.445µs   23.37%
   iterate employee   10000    292.166µs    306.554µs     14.388µs    4.92%
   iterate employee  100000   5.937789ms   6.243939ms     306.15µs    5.16%
   iterate employee 1000000  64.140997ms   80.17852ms  16.037523ms   25.00%
   iterate int64       1000     16.511µs     14.368µs     -2.143µs  -12.98%
   iterate int64      10000     262.46µs    126.381µs   -136.079µs  -51.85%
   iterate int64     100000   6.378087ms   6.439172ms     61.085µs    0.96%
   iterate int64    1000000  60.678524ms  60.375718ms   -302.806µs   -0.50%
   iterate string      1000      7.134µs      6.763µs       -371ns   -5.20%
   iterate string     10000     194.05µs     105.27µs     -88.78µs  -45.75%
   iterate string    100000   6.041565ms   6.171173ms    129.608µs    2.15%
   iterate string   1000000  64.068893ms  64.387791ms    318.898µs    0.50%
```